### PR TITLE
[AGENT] feat(engagement): add next-step links on ai trip planner page

### DIFF
--- a/ai-trip-planner/index.html
+++ b/ai-trip-planner/index.html
@@ -71,6 +71,8 @@
         .landing-links { display: flex; flex-wrap: wrap; gap: 0.75rem; margin-top: 1.5rem; }
         .landing-links a { text-decoration: none; }
         .signal-list { margin-top: 1rem; padding-left: 1.2rem; }
+        .landing-card-link { display: inline-flex; margin-top: 0.85rem; font-weight: 700; color: var(--primary-color); text-decoration: underline; text-underline-offset: 0.2em; }
+        .landing-card-link:hover { color: var(--secondary-color); }
     </style>
 </head>
 <body>
@@ -133,6 +135,32 @@
                 <li>GPT-4o cross-checks sequencing and execution logic.</li>
                 <li>Trip structure is built for planning, validation, and booking in one flow.</li>
             </ul>
+        </section>
+        <section class="landing-section">
+            <h2>Keep researching without leaving Alfred</h2>
+            <p>Analytics shows this AI Trip Planner page brings strong traffic but weaker engagement than Alfred&apos;s feature and FAQ pages. These next steps help travelers answer the practical questions they usually have before downloading or booking.</p>
+            <div class="landing-grid">
+                <div class="landing-card">
+                    <h3>See the product features behind route validation</h3>
+                    <p>Review how Alfred handles itinerary building, validation, and booking-oriented travel planning in one workflow.</p>
+                    <a href="../products.html" class="landing-card-link">Explore Alfred features</a>
+                </div>
+                <div class="landing-card">
+                    <h3>Read quick answers about setup and planning flow</h3>
+                    <p>Use the FAQ to understand how Alfred fits tutorials, itinerary questions, and travel-planning edge cases.</p>
+                    <a href="../faq.html" class="landing-card-link">Open the FAQ</a>
+                </div>
+                <div class="landing-card">
+                    <h3>Compare Alfred with other planning tools</h3>
+                    <p>See how Alfred differs from inspiration-first or chat-first planners when you need execution-ready trip structure.</p>
+                    <a href="../compare/index.html" class="landing-card-link">Compare planning tools</a>
+                </div>
+                <div class="landing-card">
+                    <h3>Start from a destination example</h3>
+                    <p>Open an itinerary example to move from broad AI trip planner research into a specific city or route.</p>
+                    <a href="../itineraries/index.html" class="landing-card-link">Browse itinerary examples</a>
+                </div>
+            </div>
         </section>
     </main>
     <footer>


### PR DESCRIPTION
## Summary
- add an internal next-step section to `ai-trip-planner/index.html`
- link high-traffic AI Trip Planner visitors to lower-bounce supporting pages: Features, FAQ, Compare, and Itineraries
- keep the change lightweight and fully static so it ships cleanly on `gh-pages`

## Analytics observations
- Last 90 days in GA showed **815 active users**, **808 new users**, **25s average engagement time per active user**, and **6.6k events**.
- Top pages/screens included:
  - `Alfred Travel: AI-powered travel planning you can actually book` — 715 views, 409 active users, 2.9k events, **52.0% bounce rate**
  - `AI Trip Planner, AI Travel Planner & AI Holiday Planner | Alfred` — 589 views, 373 active users, 2.4k events, **49.7% bounce rate**
  - `Our Features | ...` — 63 views, 44 active users, 211 events, **17.4% bounce rate**
  - `FAQ | ...` — 47 views, 26 active users, 156 events, **14.3% bounce rate**
- Opportunity chosen: the AI Trip Planner landing page gets meaningful traffic but materially weaker engagement than Features and FAQ, so adding better internal next-step links is a low-risk way to improve onward navigation.

## Google AI-optimization guidance used
From Google's guide to optimizing for generative AI features in Search:
- create **valuable, useful, people-first content**
- organize pages with **clear sections and headings** that are easy to follow
- provide content that helps users continue their task instead of vague commodity copy

This PR applies that guidance by adding a clearly labeled, practical next-step section for users comparing planners or trying to validate fit before booking.

## Why this may improve traffic / engagement / AI-search visibility
- gives a high-traffic landing page clearer onward paths to lower-bounce pages
- improves page usefulness with specific, task-oriented internal links
- strengthens crawlable, descriptive page structure around real traveler intents
- should help both human visitors and search/AI systems understand what to do next on the site

## Files changed
- `ai-trip-planner/index.html`

## Validation commands and outcomes
- `npm run build:blog` ✅
- `npm run build:itineraries` ✅
- `npm run build:compare` ✅
- `npm test` not run; no `test` script exists in `package.json`

## Responsiveness / device validation
Validated the updated AI Trip Planner page via browser/CDP on a local static server:
- Desktop 1280px: no horizontal overflow; hero CTAs visible; new cards rendered within viewport bounds
- Tablet 768px: no horizontal overflow; nav collapsed to hamburger; new cards rendered in two columns without clipping
- Mobile 390px: no horizontal overflow; nav collapsed to hamburger; new cards rendered in a single column without clipping

## Branching
- This PR was generated by the agent.
- Source branch: `agent/ga-growth-20260611-1909`
- Base branch: `gh-pages`
- This branch was created from `gh-pages` and this PR targets `gh-pages`.
