### PR TITLE
[AGENT] feat(blog): add multi-city award trip planning guide

### DIFF
--- a/_posts/multi-city-award-trip-planning-guide.md
+++ b/_posts/multi-city-award-trip-planning-guide.md
@@ -1,0 +1,155 @@
+---
+title: "How to Plan a Multi-City Award Trip Without Breaking the Route"
+description: "Award search tools can find seats and points prices, but they rarely validate whether the full trip still works once you add trains, airport transfers, hotel geography, and buffer time. This guide shows how to plan a multi-city award trip that is still usable in the real world."
+date: "2026-06-12"
+excerpt: "Finding award space is only step one. A stronger multi-city trip plan checks transfer risk, airport and station pairing, hotel location, and points-versus-cash trade-offs before you lock anything in."
+author: "Alfred Team"
+category: "Travel notes"
+tags: ["Award Travel", "Points and Miles", "Multi-City Travel", "AI Travel"]
+keywords: "multi-city award trip planner, points and miles itinerary, award travel planning, AI trip planner multi-city, Alfred Travel award trip"
+takeaways:
+  - "Award availability does not guarantee that a multi-city trip is actually workable once you add transfers, trains, hotel location, and recovery time."
+  - "Travelers should validate the full route before transferring points or mixing separate cash and award legs."
+  - "Helpful AI travel content should reduce planning risk with concrete structure, clear headings, and next-step links instead of generic inspiration alone."
+faqs:
+  - question: "Why do multi-city award trips fail so often after the search step?"
+    answer: "Because seat availability is only one layer. Many plans break when travelers ignore airport changes, station transfers, separate-ticket risk, late arrivals, or hotel placement."
+  - question: "What should I validate before transferring points?"
+    answer: "Check the city order, airport and rail-station pairing, transfer buffers, hotel location, and whether a cash leg is actually better value than forcing an award redemption."
+  - question: "Can AI help with award trip planning?"
+    answer: "Yes, when it goes beyond inspiration and helps structure a real itinerary with sequence, timing, and routing logic."
+  - question: "Where can I keep planning after reading this guide?"
+    answer: "Travelers can continue with Alfred's AI Trip Planner, review the product features page, or use Alfred's FAQ to understand how the platform supports validated trip planning."
+---
+
+Recent travel coverage is sending a consistent signal. Travel-tech publishers are treating AI booking, AI discovery, and visibility across AI platforms as operating priorities, while loyalty-focused travel publishers still win attention by helping travelers compare points, miles, and redemption value. That combination creates a practical gap: finding an award seat is not the same as having a trip that still works once the rest of the route gets real.
+
+That gap matters because many high-intent travelers do not book simple one-way itineraries. They stitch together flights, trains, hotels, and recovery days across several cities. The award search may look smart, but the trip can still break on the ground.
+
+This is exactly where structured planning content is more useful than another generic "best ways to use points" article. A traveler needs a workflow they can actually follow.
+
+## Why Award Trips Break After You Find the Seats
+
+Award tools are good at surfacing inventory. They are usually much weaker at validating the rest of the trip system around that inventory.
+
+Common failure points include:
+
+- booking into one airport and departing from another without noticing the transfer cost
+- stacking a train after a long-haul flight with too little recovery or immigration buffer
+- choosing a hotel that looks central on a map but adds friction to an early departure
+- forcing an award redemption even when a short cash leg would keep the itinerary cleaner
+- mixing separate tickets without thinking through delay risk and re-protection limits
+
+| Planning layer | What a typical award search tool helps with | What still needs validation |
+|---|---|---|
+| Flight inventory | Seat availability and mileage price | Whether the flight timing works with the rest of the route |
+| City sequence | Possible origin and destination pairs | Whether the order creates unnecessary backtracking |
+| Ground transport | Usually ignored or handled lightly | Airport-to-station transfers, transfer time, and local traffic |
+| Hotel fit | Price and review filters | Whether the hotel supports late arrivals or early departures |
+| Overall value | Cents-per-point logic | Whether the whole trip becomes simpler or more fragile |
+
+A multi-city award trip fails when one layer is optimized while the whole route is not.
+
+## A Practical Validation Workflow Before You Transfer Points
+
+### 1. Lock the city order before you chase redemptions
+
+The first decision is not "Which flight can I book with points?" It is "What is the cleanest order for this trip?"
+
+If your route is flexible, start with the sequence that reduces backtracking and expensive transfer days. A better city order often matters more than squeezing one spectacular redemption into the middle of an awkward route.
+
+For travelers comparing rail and air inside the same trip, Alfred's [rail vs. flight planning guide](rail-vs-flight-cost-analysis.html) is a good reminder that door-to-door time matters more than the headline fare alone.
+
+### 2. Check airport and station pairing, not just the arrival city
+
+"Paris" is not one airport. "London" is not one airport. A route that looks efficient in a loyalty dashboard can become much worse if it lands far from the rail station or hotel district that your next leg depends on.
+
+Before you move points, verify:
+
+- which airport you arrive at
+- whether the next leg departs from a different airport or station
+- how much buffer is realistic after immigration, baggage, or customs
+- whether a same-day transfer adds avoidable stress
+
+### 3. Compare points value against total trip friction
+
+A redemption can be technically good value and still be the wrong choice for the trip.
+
+If an award flight saves money but creates a midnight arrival, a long airport transfer, and a hotel check-in problem, it may be a weaker decision than a simpler cash fare. The right comparison is not only points versus cash on one leg. It is the full cost of the itinerary once transport friction and time loss are included.
+
+### 4. Add recovery buffers on separate-ticket days
+
+This is where many self-built itineraries become fragile.
+
+If your long-haul award lands at 1:10 p.m. and your train leaves at 3:05 p.m., the gap may look acceptable on paper but still be risky in practice. Delays, baggage, border control, or airport-to-station transfers can destroy the day.
+
+A stronger plan uses deliberate recovery space on the high-risk transitions. That may mean:
+
+- arriving the evening before a rail segment
+- sleeping near the departure airport for an early long-haul leg
+- treating the transfer day as lighter sightseeing rather than a full museum day
+
+### 5. Pick the hotel for the transport logic, not just the neighborhood brand
+
+Hotel choice is part of route planning. On a multi-city award trip, the "best" hotel is often the one that makes the trip easier to execute.
+
+Useful questions include:
+
+- Is it better to stay one night near the arrival station?
+- Does the hotel reduce risk before an early morning flight?
+- Will the neighborhood make the transfer day calmer or slower?
+
+This is also where Alfred's [features page](../products.html) and [FAQ](../faq.html) are useful follow-ons: they explain why trip planning quality depends on logistics, not just inspiration.
+
+## Where AI Actually Helps in Award Travel
+
+AI is most useful when it stops pretending to be magic and starts behaving like structure.
+
+For award travel, that means helping a traveler:
+
+1. test different city orders quickly
+2. spot where a points booking creates downstream friction
+3. compare rail, flight, and hotel combinations in one itinerary
+4. keep one source of truth for the whole trip instead of scattered tabs and screenshots
+
+That is the practical standard Alfred should meet. The goal is not to generate more ideas. The goal is to reduce breakpoints before the traveler commits money, miles, or both.
+
+If you want to continue from this article into an executable plan, start with Alfred's [AI Trip Planner](../ai-trip-planner/index.html). It is the natural next step after the research phase because it keeps the route, the timing, and the trip logic closer together.
+
+## A Simple Example: London → Paris → Milan
+
+Imagine a traveler finds:
+
+- a points flight into London
+- a rail leg to Paris
+- a short-haul flight to Milan
+- a separate hotel booking in each city
+
+The tempting mistake is to optimize each booking independently. The stronger workflow is to validate the sequence as one system:
+
+- Does the London arrival time support a same-day Eurostar without stress?
+- Is the Paris hotel chosen for sightseeing alone, or also for station access?
+- Does the Milan flight depart from an airport that changes how the final night should be planned?
+- Would one cash leg remove a weak transfer and save half a day?
+
+Those are not glamorous questions, but they are the ones that keep the trip usable.
+
+## Final Thought
+
+Search demand around points, miles, and AI travel planning is not going away. But Google is explicit that useful visibility comes from clear, original, people-first content rather than thin keyword variations or AI-search gimmicks. For Alfred, that means publishing planning guides that solve real traveler problems in plain language.
+
+A multi-city award trip is a strong example. The traveler does not just need another tool that finds a seat. They need a plan that still works after the seat is found.
+
+## FAQ: Multi-City Award Trip Planning
+
+### Why do multi-city award trips fail after I find availability?
+Because availability only solves one layer of the trip. The route can still fail on separate-ticket risk, airport changes, unrealistic buffers, and hotel placement.
+
+### What should I check before I transfer points?
+Validate the city order, airport and station pairing, transfer time, recovery buffers, and whether a cash leg would actually make the itinerary simpler.
+
+### Is the highest cents-per-point redemption always the best choice?
+No. Sometimes the best-looking redemption adds friction that makes the whole route worse. Trip quality matters as much as raw redemption value.
+
+### What should I do after reading this guide?
+Use Alfred's [AI Trip Planner](../ai-trip-planner/index.html) for the next planning pass, review [product features](../products.html), or visit the [FAQ](../faq.html) if you want a clearer view of Alfred's logistics-first approach.

--- a/blog/index.html
+++ b/blog/index.html
@@ -73,6 +73,13 @@
                     <p class="tai-agn-desc">Skift reactions, destination guides, and planning notes—newest first.</p>
                     <ul class="blog-index-list" role="list">
 <li class="blog-index-item">
+        <a href="multi-city-award-trip-planning-guide.html" class="blog-index-link">
+          <h2 class="blog-index-title">How to Plan a Multi-City Award Trip Without Breaking the Route</h2>
+          <p class="blog-index-meta">2026-06-12 &middot; Alfred Team &middot; Travel notes</p>
+          <p class="blog-index-excerpt">Award search tools can find seats and points prices, but they rarely validate whether the full trip still works once you add trains, airport transfers, hotel ge</p>
+        </a>
+      </li>
+<li class="blog-index-item">
         <a href="india-travel-ai-delhi-execution.html" class="blog-index-link">
           <h2 class="blog-index-title">India’s Travel AI Push Makes Structured Delhi Trip Planning More Valuable</h2>
           <p class="blog-index-meta">2026-06-11 &middot; Alfred Team &middot; Travel notes</p>

--- a/blog/multi-city-award-trip-planning-guide.html
+++ b/blog/multi-city-award-trip-planning-guide.html
@@ -1,0 +1,261 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>How to Plan a Multi-City Award Trip Without Breaking the Route | Alfred Travel Blog</title>
+    <meta name="description" content="Award search tools can find seats and points prices, but they rarely validate whether the full trip still works once you add trains, airport transfers, hotel geography, and buffer time. This guide shows how to plan a multi-city award trip that is still usable in the real world.">
+    <meta name="keywords" content="multi-city award trip planner, points and miles itinerary, award travel planning, AI trip planner multi-city, Alfred Travel award trip">
+    <link rel="canonical" href="https://www.alfredtravel.io/blog/multi-city-award-trip-planning-guide.html">
+    <link rel="icon" type="image/png" href="/images/brand/alfred-logo-header.png">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../css/tokens.css">
+    <link rel="stylesheet" href="../css/styles.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "SoftwareApplication",
+  "name": "Alfred Travel",
+  "operatingSystem": "iOS, Android, Web",
+  "applicationCategory": "TravelApplication",
+  "offers": {
+    "@type": "Offer",
+    "price": "0.00",
+    "priceCurrency": "USD"
+  },
+  "description": "Alfred is an AI travel planner for validated itineraries, multi-city travel, and booking-ready execution.",
+  "featureList": "AI Trip Planner, Validated Multi-City Planning, Booking-Ready Travel Flow, Google Maps Integration, Loyalty Rewards",
+  "softwareVersion": "1.0.18"
+}
+    </script>
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BlogPosting",
+  "headline": "How to Plan a Multi-City Award Trip Without Breaking the Route",
+  "description": "Award search tools can find seats and points prices, but they rarely validate whether the full trip still works once you add trains, airport transfers, hotel geography, and buffer time. This guide shows how to plan a multi-city award trip that is still usable in the real world.",
+  "datePublished": "2026-06-12",
+  "author": {
+    "@type": "Person",
+    "name": "Alfred Team"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "Alfred Travel Tech Pty Ltd",
+    "url": "https://www.alfredtravel.io"
+  },
+  "url": "https://www.alfredtravel.io/blog/multi-city-award-trip-planning-guide.html"
+}
+    </script>
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": "https://www.alfredtravel.io/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Blog",
+      "item": "https://www.alfredtravel.io/blog/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "name": "Travel notes",
+      "item": "https://www.alfredtravel.io/blog/?category=Travel%20notes"
+    },
+    {
+      "@type": "ListItem",
+      "position": 4,
+      "name": "How to Plan a Multi-City Award Trip Without Breaking the Route",
+      "item": "https://www.alfredtravel.io/blog/multi-city-award-trip-planning-guide.html"
+    }
+  ]
+}
+    </script>
+    <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"Why do multi-city award trips fail so often after the search step?","acceptedAnswer":{"@type":"Answer","text":"Because seat availability is only one layer. Many plans break when travelers ignore airport changes, station transfers, separate-ticket risk, late arrivals, or hotel placement."}},{"@type":"Question","name":"What should I validate before transferring points?","acceptedAnswer":{"@type":"Answer","text":"Check the city order, airport and rail-station pairing, transfer buffers, hotel location, and whether a cash leg is actually better value than forcing an award redemption."}},{"@type":"Question","name":"Can AI help with award trip planning?","acceptedAnswer":{"@type":"Answer","text":"Yes, when it goes beyond inspiration and helps structure a real itinerary with sequence, timing, and routing logic."}},{"@type":"Question","name":"Where can I keep planning after reading this guide?","acceptedAnswer":{"@type":"Answer","text":"Travelers can continue with Alfred's AI Trip Planner, review the product features page, or use Alfred's FAQ to understand how the platform supports validated trip planning."}}]}
+    </script>
+</head>
+<body class="blog-page">
+
+    <header>
+        <nav class="navbar" aria-label="Main navigation">
+            <div class="logo">
+                <a href="../index.html" class="brand-link" aria-label="Alfred Travel home">
+                    <img src="../images/Color logo with background.png.png" alt="Alfred Travel" class="logo-image" />
+                </a>
+            </div>
+            <ul class="nav-links">
+                <li><a href="../products.html">Features</a></li>
+                <li><a href="../itineraries/index.html">Itineraries</a></li>
+                <li><a href="index.html" class="nav-blog-active">Blog</a></li>
+                <li><a href="../compare/index.html">Compare</a></li>
+                <li><a href="../faq.html">FAQ</a></li>
+            </ul>
+            <a href="../index.html#app-downloads" class="download-cta" aria-label="Download Alfred on iOS or Android">Download App</a>
+            <div class="hamburger"><span></span><span></span><span></span></div>
+        </nav>
+    </header>
+    <main class="blog-main">
+        <article class="blog-article">
+            <nav class="blog-breadcrumb" aria-label="Breadcrumb">Home &rarr; <a href="index.html">Blog</a> &rarr; Travel notes &rarr; <span>How to Plan a Multi-City Award Trip Without Breaking the Route</span></nav>
+            <header class="blog-article-header">
+                <p class="blog-meta"><time datetime="2026-06-12">2026-06-12</time> &middot; Alfred Team &middot; Travel notes</p>
+                <h1 class="blog-article-title">How to Plan a Multi-City Award Trip Without Breaking the Route</h1>
+            </header>
+            <aside class="blog-takeaways-callout" aria-label="Key takeaways">
+    <h3 class="blog-takeaways-title">Key takeaways</h3>
+    <ul class="blog-takeaways-list"><li>Award availability does not guarantee that a multi-city trip is actually workable once you add transfers, trains, hotel location, and recovery time.</li>
+<li>Travelers should validate the full route before transferring points or mixing separate cash and award legs.</li>
+<li>Helpful AI travel content should reduce planning risk with concrete structure, clear headings, and next-step links instead of generic inspiration alone.</li></ul>
+  </aside>
+            <div class="blog-article-body"><p>Recent travel coverage is sending a consistent signal. Travel-tech publishers are treating AI booking, AI discovery, and visibility across AI platforms as operating priorities, while loyalty-focused travel publishers still win attention by helping travelers compare points, miles, and redemption value. That combination creates a practical gap: finding an award seat is not the same as having a trip that still works once the rest of the route gets real.</p>
+<p>That gap matters because many high-intent travelers do not book simple one-way itineraries. They stitch together flights, trains, hotels, and recovery days across several cities. The award search may look smart, but the trip can still break on the ground.</p>
+<p>This is exactly where structured planning content is more useful than another generic &quot;best ways to use points&quot; article. A traveler needs a workflow they can actually follow.</p>
+<h2>Why Award Trips Break After You Find the Seats</h2>
+<p>Award tools are good at surfacing inventory. They are usually much weaker at validating the rest of the trip system around that inventory.</p>
+<p>Common failure points include:</p>
+<ul>
+<li>booking into one airport and departing from another without noticing the transfer cost</li>
+<li>stacking a train after a long-haul flight with too little recovery or immigration buffer</li>
+<li>choosing a hotel that looks central on a map but adds friction to an early departure</li>
+<li>forcing an award redemption even when a short cash leg would keep the itinerary cleaner</li>
+<li>mixing separate tickets without thinking through delay risk and re-protection limits</li>
+</ul>
+<table>
+<thead>
+<tr>
+<th>Planning layer</th>
+<th>What a typical award search tool helps with</th>
+<th>What still needs validation</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>Flight inventory</td>
+<td>Seat availability and mileage price</td>
+<td>Whether the flight timing works with the rest of the route</td>
+</tr>
+<tr>
+<td>City sequence</td>
+<td>Possible origin and destination pairs</td>
+<td>Whether the order creates unnecessary backtracking</td>
+</tr>
+<tr>
+<td>Ground transport</td>
+<td>Usually ignored or handled lightly</td>
+<td>Airport-to-station transfers, transfer time, and local traffic</td>
+</tr>
+<tr>
+<td>Hotel fit</td>
+<td>Price and review filters</td>
+<td>Whether the hotel supports late arrivals or early departures</td>
+</tr>
+<tr>
+<td>Overall value</td>
+<td>Cents-per-point logic</td>
+<td>Whether the whole trip becomes simpler or more fragile</td>
+</tr>
+</tbody></table>
+<p>A multi-city award trip fails when one layer is optimized while the whole route is not.</p>
+<h2>A Practical Validation Workflow Before You Transfer Points</h2>
+<h3>1. Lock the city order before you chase redemptions</h3>
+<p>The first decision is not &quot;Which flight can I book with points?&quot; It is &quot;What is the cleanest order for this trip?&quot;</p>
+<p>If your route is flexible, start with the sequence that reduces backtracking and expensive transfer days. A better city order often matters more than squeezing one spectacular redemption into the middle of an awkward route.</p>
+<p>For travelers comparing rail and air inside the same trip, Alfred&#39;s <a href="rail-vs-flight-cost-analysis.html">rail vs. flight planning guide</a> is a good reminder that door-to-door time matters more than the headline fare alone.</p>
+<h3>2. Check airport and station pairing, not just the arrival city</h3>
+<p>&quot;Paris&quot; is not one airport. &quot;London&quot; is not one airport. A route that looks efficient in a loyalty dashboard can become much worse if it lands far from the rail station or hotel district that your next leg depends on.</p>
+<p>Before you move points, verify:</p>
+<ul>
+<li>which airport you arrive at</li>
+<li>whether the next leg departs from a different airport or station</li>
+<li>how much buffer is realistic after immigration, baggage, or customs</li>
+<li>whether a same-day transfer adds avoidable stress</li>
+</ul>
+<h3>3. Compare points value against total trip friction</h3>
+<p>A redemption can be technically good value and still be the wrong choice for the trip.</p>
+<p>If an award flight saves money but creates a midnight arrival, a long airport transfer, and a hotel check-in problem, it may be a weaker decision than a simpler cash fare. The right comparison is not only points versus cash on one leg. It is the full cost of the itinerary once transport friction and time loss are included.</p>
+<h3>4. Add recovery buffers on separate-ticket days</h3>
+<p>This is where many self-built itineraries become fragile.</p>
+<p>If your long-haul award lands at 1:10 p.m. and your train leaves at 3:05 p.m., the gap may look acceptable on paper but still be risky in practice. Delays, baggage, border control, or airport-to-station transfers can destroy the day.</p>
+<p>A stronger plan uses deliberate recovery space on the high-risk transitions. That may mean:</p>
+<ul>
+<li>arriving the evening before a rail segment</li>
+<li>sleeping near the departure airport for an early long-haul leg</li>
+<li>treating the transfer day as lighter sightseeing rather than a full museum day</li>
+</ul>
+<h3>5. Pick the hotel for the transport logic, not just the neighborhood brand</h3>
+<p>Hotel choice is part of route planning. On a multi-city award trip, the &quot;best&quot; hotel is often the one that makes the trip easier to execute.</p>
+<p>Useful questions include:</p>
+<ul>
+<li>Is it better to stay one night near the arrival station?</li>
+<li>Does the hotel reduce risk before an early morning flight?</li>
+<li>Will the neighborhood make the transfer day calmer or slower?</li>
+</ul>
+<p>This is also where Alfred&#39;s <a href="../products.html">features page</a> and <a href="../faq.html">FAQ</a> are useful follow-ons: they explain why trip planning quality depends on logistics, not just inspiration.</p>
+<h2>Where AI Actually Helps in Award Travel</h2>
+<p>AI is most useful when it stops pretending to be magic and starts behaving like structure.</p>
+<p>For award travel, that means helping a traveler:</p>
+<ol>
+<li>test different city orders quickly</li>
+<li>spot where a points booking creates downstream friction</li>
+<li>compare rail, flight, and hotel combinations in one itinerary</li>
+<li>keep one source of truth for the whole trip instead of scattered tabs and screenshots</li>
+</ol>
+<p>That is the practical standard Alfred should meet. The goal is not to generate more ideas. The goal is to reduce breakpoints before the traveler commits money, miles, or both.</p>
+<p>If you want to continue from this article into an executable plan, start with Alfred&#39;s <a href="../ai-trip-planner/index.html">AI Trip Planner</a>. It is the natural next step after the research phase because it keeps the route, the timing, and the trip logic closer together.</p>
+<h2>A Simple Example: London → Paris → Milan</h2>
+<p>Imagine a traveler finds:</p>
+<ul>
+<li>a points flight into London</li>
+<li>a rail leg to Paris</li>
+<li>a short-haul flight to Milan</li>
+<li>a separate hotel booking in each city</li>
+</ul>
+<p>The tempting mistake is to optimize each booking independently. The stronger workflow is to validate the sequence as one system:</p>
+<ul>
+<li>Does the London arrival time support a same-day Eurostar without stress?</li>
+<li>Is the Paris hotel chosen for sightseeing alone, or also for station access?</li>
+<li>Does the Milan flight depart from an airport that changes how the final night should be planned?</li>
+<li>Would one cash leg remove a weak transfer and save half a day?</li>
+</ul>
+<p>Those are not glamorous questions, but they are the ones that keep the trip usable.</p>
+<h2>Final Thought</h2>
+<p>Search demand around points, miles, and AI travel planning is not going away. But Google is explicit that useful visibility comes from clear, original, people-first content rather than thin keyword variations or AI-search gimmicks. For Alfred, that means publishing planning guides that solve real traveler problems in plain language.</p>
+<p>A multi-city award trip is a strong example. The traveler does not just need another tool that finds a seat. They need a plan that still works after the seat is found.</p>
+<h2>FAQ: Multi-City Award Trip Planning</h2>
+<h3>Why do multi-city award trips fail after I find availability?</h3>
+<p>Because availability only solves one layer of the trip. The route can still fail on separate-ticket risk, airport changes, unrealistic buffers, and hotel placement.</p>
+<h3>What should I check before I transfer points?</h3>
+<p>Validate the city order, airport and station pairing, transfer time, recovery buffers, and whether a cash leg would actually make the itinerary simpler.</p>
+<h3>Is the highest cents-per-point redemption always the best choice?</h3>
+<p>No. Sometimes the best-looking redemption adds friction that makes the whole route worse. Trip quality matters as much as raw redemption value.</p>
+<h3>What should I do after reading this guide?</h3>
+<p>Use Alfred&#39;s <a href="../ai-trip-planner/index.html">AI Trip Planner</a> for the next planning pass, review <a href="../products.html">product features</a>, or visit the <a href="../faq.html">FAQ</a> if you want a clearer view of Alfred&#39;s logistics-first approach.</p>
+</div>
+        </article>
+    </main>
+
+    <footer>
+        <div class="footer-content">
+            <div class="footer-column"><h3>Company</h3><ul class="footer-links"><li><a href="../about.html">About Us</a></li><li><a href="../about.html#mission">Our Mission</a></li><li><a href="../about.html#team">Our Team</a></li><li><a href="../index.html#features">Features</a></li></ul></div>
+            <div class="footer-column"><h3>Features</h3><ul class="footer-links"><li><a href="../products.html">Our Features</a></li><li><a href="../itineraries/index.html">Itineraries</a></li><li><a href="../compare/index.html">Compare</a></li><li><a href="index.html">Blog</a></li><li><a href="../faq.html">FAQ</a></li></ul></div>
+            <div class="footer-column"><h3>Solutions</h3><ul class="footer-links"><li><a href="../ai-trip-planner/index.html">AI Trip Planner</a></li><li><a href="../ai-travel-planner/index.html">AI Travel Planner</a></li><li><a href="../ai-holiday-planner/index.html">AI Holiday Planner</a></li></ul></div>
+            <div class="footer-column"><h3>Support</h3><ul class="footer-links"><li><a href="../delete-account.html">Support Center</a></li><li><a href="../index.html#contact">Contact Us</a></li><li><a href="../faq.html">Help & FAQ</a></li></ul></div>
+            <div class="footer-column"><h3>Legal</h3><ul class="footer-links"><li><a href="../terms.html">Terms & Conditions</a></li><li><a href="../terms.html#privacy">Privacy Policy</a></li><li><a href="../prize-tc.html">Prize Terms</a></li></ul></div>
+        </div>
+        <div class="footer-bottom"><p>&copy; 2026 Alfred Travel Tech Pty Ltd. All rights reserved.</p></div>
+    </footer>
+    <div id="cookies-banner" class="cookies-banner"><div class="cookies-content"><div class="cookies-text"><h3>🍪 We use cookies</h3><p>We use cookies and similar technologies. <a href="../terms.html#privacy" class="cookies-link">Privacy Policy</a> · <a href="#" class="cookies-link" id="cookie-settings">Cookie Settings</a>.</p></div><div class="cookies-buttons"><button id="accept-all-cookies" class="btn btn-primary">Accept All</button><button id="reject-cookies" class="btn btn-secondary">Reject All</button></div></div></div>
+    <script src="../js/main.js"></script>
+</body>
+</html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -12,6 +12,7 @@
   <url><loc>https://www.alfredtravel.io/terms.html</loc><changefreq>monthly</changefreq><priority>0.5</priority></url>
   <url><loc>https://www.alfredtravel.io/delete-account.html</loc><changefreq>monthly</changefreq><priority>0.5</priority></url>
   <url><loc>https://www.alfredtravel.io/prize-tc.html</loc><changefreq>monthly</changefreq><priority>0.5</priority></url>
+  <url><loc>https://www.alfredtravel.io/blog/multi-city-award-trip-planning-guide.html</loc><lastmod>2026-06-12</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
   <url><loc>https://www.alfredtravel.io/blog/india-travel-ai-delhi-execution.html</loc><lastmod>2026-06-11</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
   <url><loc>https://www.alfredtravel.io/blog/skift-b2a-ai-agents-travel-alfred-aio.html</loc><lastmod>2026-05-25</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
   <url><loc>https://www.alfredtravel.io/blog/skift-india-voice-first-travel-alfred.html</loc><lastmod>2026-05-24</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>


### PR DESCRIPTION
## Summary
Add a new original blog guide focused on planning multi-city award trips without breaking route logic.

## Analytics observations
- Last 90 days GA4 report showed **837 active users**, **830 new users**, **25s average engagement time per active user**, and **6.8k events**.
- Top pages/screens were concentrated on landing pages rather than blog content:
  - `Alfred Travel: AI-powered travel planning you can actually book` — 758 views, 433 active users, 51.7% bounce rate
  - `AI Trip Planner, AI Travel Planner & AI Holiday Planner | Alfred` — 584 views, 368 active users, 49.5% bounce rate
  - `FAQ | Superior AI Travel Logistics...` — 47 views, 26 active users, 14.3% bounce rate
- Source mix showed **google / organic = 162 active users, 240 sessions** and **chatgpt.com = 26 sessions combined**, which supports publishing more search- and AI-retrievable informational content.

## Google AI-optimization guidance used
- Followed Google's guidance to create **unique, non-commodity, people-first content** instead of scaled keyword variants.
- Used a **clear heading structure**, practical sections, and FAQ answers so the page is easier for users and AI retrieval systems to interpret.
- Preserved existing crawlable/indexable structure and avoided unsupported GEO/AEO hacks such as llms.txt or chunking-for-chunking's-sake.

## External sources reviewed and how they informed the change
- **Skift** (`https://skift.com/`): homepage coverage emphasized AI booking operations and execution problems in travel tech. This reinforced writing a post about the execution gap after award discovery.
- **PhocusWire** (`https://www.phocuswire.com/`): homepage coverage highlighted AI-platform visibility, productivity gains, and booking-journey speed. This supported a guide optimized for AI-search discoverability and practical next steps.
- **The Points Guy** (`https://thepointsguy.com/`): homepage emphasis on points valuations, awards calculators, and loyalty content showed strong traveler demand around award optimization. This shaped the points-and-miles angle.
- **Nomadic Matt** (`https://www.nomadicmatt.com/`): homepage structure emphasized step-based trip planning resources, which informed the checklist/workflow framing of the article.

## Why this may improve traffic / engagement / AI-search visibility
- Targets a specific high-intent query cluster adjacent to Alfred's multi-city planning strength: **award travel + route validation**.
- Adds original, structured content that can rank independently while internally reinforcing Alfred's AI trip planning proposition.
- Includes internal links to Alfred product/support pages for stronger onward navigation without changing site layout.
- Adds FAQ schema via the existing blog build pipeline, improving structured eligibility for search surfaces.

## Files changed
- `_posts/multi-city-award-trip-planning-guide.md`
- `blog/multi-city-award-trip-planning-guide.html`
- `blog/index.html`
- `sitemap.xml`

## Validation commands and outcomes
- `npm run build:blog` ✅
- `npm run build:itineraries` ✅
- `npm run build:compare` ✅
- `npm test` not run because `package.json` currently has no `test` script.

## Layout note
- Existing site layout was intentionally preserved. This PR only adds content and regenerated content artifacts.

## Branching note
- This PR was created by the agent.
- Source branch: `agent/ga-growth-20260612-1638`
- Base branch: `gh-pages`
- This work was branched from `gh-pages` and targets `gh-pages`.
