### PR TITLE
[AGENT] feat(blog): add multi-city family AI planning guide

### DIFF
--- a/_posts/multi-city-family-trip-ai-guide.md
+++ b/_posts/multi-city-family-trip-ai-guide.md
@@ -1,0 +1,158 @@
+---
+title: "How to Plan a Multi-City Family Trip With AI Without Breaking the Schedule"
+description: "Family trips fail on transfer timing, room logistics, and overpacked days. Use this practical AI planning framework to build a multi-city family itinerary that stays realistic and bookable."
+date: "2026-06-13"
+excerpt: "A stronger family itinerary starts before the first attraction. Here is how to use AI for pacing, transfer buffers, rooms, and booking continuity across a multi-city trip."
+author: "Alfred Team"
+category: "Family travel"
+tags: ["AI Travel", "Family Travel", "Multi-City", "Trip Planning"]
+keywords: "AI family trip planner, multi-city family itinerary, family travel planner, AI trip planner for families, Alfred Travel"
+takeaways:
+  - "Family trips expose weak AI planning fast because transfer friction, nap windows, room setup, and ticket timing all compound across cities."
+  - "A useful AI trip planner should structure the trip around recovery blocks, realistic travel days, and booking continuity instead of attraction volume."
+  - "Alfred can support family planning with route validation, sample destination pages, and booking-ready next steps for trips such as Orlando and Bali."
+faqs:
+  - question: "Why are family trips harder for generic AI planners?"
+    answer: "Family trips add more constraints at once: sleep schedules, energy swings, seat assignments, room configuration, and transfer buffers. Generic AI can suggest activities, but it often underestimates how those details interact across multiple cities."
+  - question: "What should a family decide before asking AI to build the itinerary?"
+    answer: "Start with ages, mobility needs, daily pace, luggage load, flight tolerance, and non-negotiable moments. The clearer the brief, the more useful the itinerary becomes."
+  - question: "How many major activities should a family plan per day?"
+    answer: "For most multi-city family trips, one anchor activity plus one lighter supporting block is more sustainable than trying to stack a full adult sightseeing day on top of travel logistics."
+  - question: "Can AI help with family booking continuity too?"
+    answer: "It should. A stronger planning workflow keeps rooms, transfer days, seat selection, ticket timing, and hotel location logic visible so the plan stays executable when you move from ideas to booking."
+  - question: "Where can I see practical examples after reading this guide?"
+    answer: "Use Alfred’s AI Trip Planner page for the validation overview, then review the Orlando and Bali itinerary examples and the family-focused Bali guide for concrete pacing patterns."
+---
+
+A family trip can look efficient on paper and still fail in real life.
+
+That usually happens when a plan treats parents, kids, luggage, airport timing, and hotel changes as minor details instead of the core job. A generic AI tool might suggest a clean list of cities and attractions. The harder part is building a route that survives early flights, midday crashes, room handoffs, and the reality that one delayed transfer can disrupt the whole day.
+
+That is where a stronger **[AI Trip Planner](../ai-trip-planner/index.html)** should help. It should not just answer “where should we go?” It should help answer “what pace will still work on day four?”
+
+## Why Family Travel Breaks Weak Itineraries So Quickly
+
+Family trips create compounding friction:
+
+- **arrival days are slower** because bags, transport, snacks, and check-in all take longer
+- **energy levels diverge** between adults, toddlers, teens, and grandparents
+- **room setup matters** because adjoining rooms, bedding needs, and walkability affect the rest of the stay
+- **tickets and bookings interact** because one late arrival can wreck a timed activity or dinner reservation
+- **multi-city moves cost more** when every transfer burns time and patience
+
+A couple on a city break can improvise around bad sequencing. A family moving across multiple stops usually pays for it immediately.
+
+## Start With the Family Brief Before the Destination List
+
+Before asking AI for an itinerary, define the operating constraints.
+
+A useful family brief should cover:
+
+1. **Ages and mobility** — stroller, car seat, walking tolerance, or accessibility needs
+2. **Morning vs evening energy** — who is freshest when, and how late the group can reasonably stay out
+3. **Luggage load** — carry-on only, checked bags, sports gear, or baby equipment
+4. **Must-do moments** — the one or two experiences that matter most in each stop
+5. **Non-negotiable recovery time** — naps, pool breaks, quiet afternoons, or slow mornings after travel
+
+This matters because AI gets better when the trip brief is concrete. If the prompt is vague, the itinerary usually becomes too adult-paced, too attraction-dense, or too optimistic about transport.
+
+If you want a clean overview of Alfred’s planning model before going deeper, the **[FAQ](../faq.html)** explains how family profiles, itinerary validation, and booking partners fit together.
+
+## Build Around Transfer Friction, Not Attraction Volume
+
+The biggest family-planning mistake is counting sights without pricing the travel day between them.
+
+A better rule is to treat each city change as the main event for that block. Then layer the rest around it.
+
+### What that looks like in practice
+
+- **Arrival day:** one soft landing activity, not a full sightseeing sprint
+- **Transfer day:** one neighborhood or one anchor experience after check-in, not three scattered stops
+- **Full day:** one major attraction plus one lighter supporting block
+- **Departure day:** protect airport or station buffers first, then add anything optional
+
+This is why route-aware planning matters more for families than for solo travelers. The trip does not fail because the museum was bad. It fails because the plan assumed the family could land, transfer, check in, eat, and cross town again without losing momentum.
+
+## Choose One Anchor Per City
+
+Multi-city family trips become easier when each stop has a simple identity.
+
+Instead of trying to “do everything,” define one anchor for each place:
+
+- **Orlando:** theme-park core with built-in rest and weather buffers
+- **Bali:** split between one coastal base and one inland base, not endless hotel hopping
+- **Paris:** one museum day, one neighborhood day, one flexible food-and-park day
+
+That gives AI a stronger frame for sequencing.
+
+It also makes internal trade-offs clearer. If the city anchor is a park-heavy day, you know the night before should stay light. If the anchor is a transfer plus evening food walk, you know not to book the hardest museum morning right after it.
+
+For Alfred examples, review the **[Orlando itinerary](../itineraries/orlando.html)** and **[Bali itinerary](../itineraries/bali.html)** after this guide. Both show how a destination page can start with pace and logistics instead of an unfiltered list of things to do.
+
+## Protect Recovery Blocks on Purpose
+
+Families do not need more enthusiasm from AI. They need permission to leave space.
+
+Recovery blocks are not dead time. They are the reason the rest of the trip works.
+
+Useful recovery blocks include:
+
+- hotel pool or playground time after a long morning
+- a late breakfast after an arrival day
+- one low-decision meal close to the hotel
+- one evening with nothing ticketed
+- a half day between two intense city or theme-park blocks
+
+This is also where creator-style travel content is useful as inspiration but not enough on its own. Beautiful destination roundups can help with ideas, but a family still needs the execution layer: when to slow down, what to cluster, and what to skip.
+
+## Keep Booking Continuity Visible
+
+A family itinerary stops being useful when the planning layer and booking layer drift apart.
+
+As the route firms up, keep these questions visible:
+
+- Are the hotel locations still right for the daily plan?
+- Do room types match the family composition?
+- Are seat assignments or rail reservations needed before the trip sells out?
+- Are long transfer days followed by low-friction evenings?
+- Does the timed ticket require a different breakfast, taxi, or wake-up window than the draft assumed?
+
+This is one reason Alfred’s positioning should stay execution-first. The goal is not to generate more ideas. The goal is to move from ideas to a plan that is still coherent when bookings start locking in.
+
+## Use Examples, Then Adapt
+
+Families often plan faster when they start from a route pattern instead of a blank page.
+
+If your trip involves a resort-plus-activities rhythm, the **[Bali family guide](bali-for-families.html)** is a useful example of how to think about drive times, rest windows, and child-friendly pacing. If your trip is park-heavy or ticket-heavy, the **[Orlando itinerary](../itineraries/orlando.html)** shows how to protect the group from heat, overstacking, and departure-day chaos.
+
+Those examples should not be copied city for city. They are useful because they show a structure:
+
+- one clear base
+- one daily anchor
+- protected rest windows
+- transfer logic that matches the group
+- enough flexibility to recover when the day shifts
+
+## Final Thought
+
+The best family trips rarely feel the most ambitious on paper. They feel the most survivable once the trip is underway.
+
+That is the standard a strong AI itinerary should meet. It should help a family move across cities without losing the booking thread, the recovery time, or the energy to enjoy the reason they traveled in the first place.
+
+## FAQ: Planning a Family Trip With AI
+
+### Why are family trips harder for generic AI planners?
+
+Because the trip has more interacting constraints. Kids, bags, rooms, transport timing, and group energy all affect whether the route is realistic.
+
+### What should a family decide before asking AI to build the route?
+
+Set the brief first: ages, pace, mobility needs, luggage load, must-do moments, and what a successful day actually feels like for the group.
+
+### How many major activities should a family plan per day?
+
+Usually one anchor activity plus one lighter block. More than that often creates hidden transport and fatigue costs, especially across multiple cities.
+
+### Where should I go next after reading this?
+
+Start with Alfred’s **[AI Trip Planner](../ai-trip-planner/index.html)** for the validation overview, then review the **[Orlando itinerary](../itineraries/orlando.html)**, **[Bali itinerary](../itineraries/bali.html)**, and **[FAQ](../faq.html)** for practical next steps.

--- a/ai-trip-planner/index.html
+++ b/ai-trip-planner/index.html
@@ -71,6 +71,7 @@
         .landing-links { display: flex; flex-wrap: wrap; gap: 0.75rem; margin-top: 1.5rem; }
         .landing-links a { text-decoration: none; }
         .signal-list { margin-top: 1rem; padding-left: 1.2rem; }
+        .landing-resource-note { margin-top: 1rem; }
     </style>
 </head>
 <body>
@@ -133,6 +134,7 @@
                 <li>GPT-4o cross-checks sequencing and execution logic.</li>
                 <li>Trip structure is built for planning, validation, and booking in one flow.</li>
             </ul>
+            <p class="landing-resource-note">Planning for kids or mixed-energy groups? Read our <a href="../blog/multi-city-family-trip-ai-guide.html">multi-city family AI planning guide</a>, then review the <a href="../itineraries/orlando.html">Orlando</a> and <a href="../itineraries/bali.html">Bali</a> itinerary examples or the <a href="../faq.html">FAQ</a> for booking and profile details.</p>
         </section>
     </main>
     <footer>

--- a/blog/index.html
+++ b/blog/index.html
@@ -73,6 +73,13 @@
                     <p class="tai-agn-desc">Skift reactions, destination guides, and planning notes—newest first.</p>
                     <ul class="blog-index-list" role="list">
 <li class="blog-index-item">
+        <a href="multi-city-family-trip-ai-guide.html" class="blog-index-link">
+          <h2 class="blog-index-title">How to Plan a Multi-City Family Trip With AI Without Breaking the Schedule</h2>
+          <p class="blog-index-meta">2026-06-13 &middot; Alfred Team &middot; Family travel</p>
+          <p class="blog-index-excerpt">Family trips fail on transfer timing, room logistics, and overpacked days. Use this practical AI planning framework to build a multi-city family itinerary that </p>
+        </a>
+      </li>
+<li class="blog-index-item">
         <a href="india-travel-ai-delhi-execution.html" class="blog-index-link">
           <h2 class="blog-index-title">India’s Travel AI Push Makes Structured Delhi Trip Planning More Valuable</h2>
           <p class="blog-index-meta">2026-06-11 &middot; Alfred Team &middot; Travel notes</p>

--- a/blog/multi-city-family-trip-ai-guide.html
+++ b/blog/multi-city-family-trip-ai-guide.html
@@ -1,0 +1,232 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>How to Plan a Multi-City Family Trip With AI Without Breaking the Schedule | Alfred Travel Blog</title>
+    <meta name="description" content="Family trips fail on transfer timing, room logistics, and overpacked days. Use this practical AI planning framework to build a multi-city family itinerary that stays realistic and bookable.">
+    <meta name="keywords" content="AI family trip planner, multi-city family itinerary, family travel planner, AI trip planner for families, Alfred Travel">
+    <link rel="canonical" href="https://www.alfredtravel.io/blog/multi-city-family-trip-ai-guide.html">
+    <link rel="icon" type="image/png" href="/images/brand/alfred-logo-header.png">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../css/tokens.css">
+    <link rel="stylesheet" href="../css/styles.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "SoftwareApplication",
+  "name": "Alfred Travel",
+  "operatingSystem": "iOS, Android, Web",
+  "applicationCategory": "TravelApplication",
+  "offers": {
+    "@type": "Offer",
+    "price": "0.00",
+    "priceCurrency": "USD"
+  },
+  "description": "Alfred is an AI travel planner for validated itineraries, multi-city travel, and booking-ready execution.",
+  "featureList": "AI Trip Planner, Validated Multi-City Planning, Booking-Ready Travel Flow, Google Maps Integration, Loyalty Rewards",
+  "softwareVersion": "1.0.18"
+}
+    </script>
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BlogPosting",
+  "headline": "How to Plan a Multi-City Family Trip With AI Without Breaking the Schedule",
+  "description": "Family trips fail on transfer timing, room logistics, and overpacked days. Use this practical AI planning framework to build a multi-city family itinerary that stays realistic and bookable.",
+  "datePublished": "2026-06-13",
+  "author": {
+    "@type": "Person",
+    "name": "Alfred Team"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "Alfred Travel Tech Pty Ltd",
+    "url": "https://www.alfredtravel.io"
+  },
+  "url": "https://www.alfredtravel.io/blog/multi-city-family-trip-ai-guide.html"
+}
+    </script>
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": "https://www.alfredtravel.io/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Blog",
+      "item": "https://www.alfredtravel.io/blog/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "name": "Family travel",
+      "item": "https://www.alfredtravel.io/blog/?category=Family%20travel"
+    },
+    {
+      "@type": "ListItem",
+      "position": 4,
+      "name": "How to Plan a Multi-City Family Trip With AI Without Breaking the Schedule",
+      "item": "https://www.alfredtravel.io/blog/multi-city-family-trip-ai-guide.html"
+    }
+  ]
+}
+    </script>
+    <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"Why are family trips harder for generic AI planners?","acceptedAnswer":{"@type":"Answer","text":"Family trips add more constraints at once: sleep schedules, energy swings, seat assignments, room configuration, and transfer buffers. Generic AI can suggest activities, but it often underestimates how those details interact across multiple cities."}},{"@type":"Question","name":"What should a family decide before asking AI to build the itinerary?","acceptedAnswer":{"@type":"Answer","text":"Start with ages, mobility needs, daily pace, luggage load, flight tolerance, and non-negotiable moments. The clearer the brief, the more useful the itinerary becomes."}},{"@type":"Question","name":"How many major activities should a family plan per day?","acceptedAnswer":{"@type":"Answer","text":"For most multi-city family trips, one anchor activity plus one lighter supporting block is more sustainable than trying to stack a full adult sightseeing day on top of travel logistics."}},{"@type":"Question","name":"Can AI help with family booking continuity too?","acceptedAnswer":{"@type":"Answer","text":"It should. A stronger planning workflow keeps rooms, transfer days, seat selection, ticket timing, and hotel location logic visible so the plan stays executable when you move from ideas to booking."}},{"@type":"Question","name":"Where can I see practical examples after reading this guide?","acceptedAnswer":{"@type":"Answer","text":"Use Alfred’s AI Trip Planner page for the validation overview, then review the Orlando and Bali itinerary examples and the family-focused Bali guide for concrete pacing patterns."}}]}
+    </script>
+</head>
+<body class="blog-page">
+
+    <header>
+        <nav class="navbar" aria-label="Main navigation">
+            <div class="logo">
+                <a href="../index.html" class="brand-link" aria-label="Alfred Travel home">
+                    <img src="../images/Color logo with background.png.png" alt="Alfred Travel" class="logo-image" />
+                </a>
+            </div>
+            <ul class="nav-links">
+                <li><a href="../products.html">Features</a></li>
+                <li><a href="../itineraries/index.html">Itineraries</a></li>
+                <li><a href="index.html" class="nav-blog-active">Blog</a></li>
+                <li><a href="../compare/index.html">Compare</a></li>
+                <li><a href="../faq.html">FAQ</a></li>
+            </ul>
+            <a href="../index.html#app-downloads" class="download-cta" aria-label="Download Alfred on iOS or Android">Download App</a>
+            <div class="hamburger"><span></span><span></span><span></span></div>
+        </nav>
+    </header>
+    <main class="blog-main">
+        <article class="blog-article">
+            <nav class="blog-breadcrumb" aria-label="Breadcrumb">Home &rarr; <a href="index.html">Blog</a> &rarr; Family travel &rarr; <span>How to Plan a Multi-City Family Trip With AI Without Breaking the Schedule</span></nav>
+            <header class="blog-article-header">
+                <p class="blog-meta"><time datetime="2026-06-13">2026-06-13</time> &middot; Alfred Team &middot; Family travel</p>
+                <h1 class="blog-article-title">How to Plan a Multi-City Family Trip With AI Without Breaking the Schedule</h1>
+            </header>
+            <aside class="blog-takeaways-callout" aria-label="Key takeaways">
+    <h3 class="blog-takeaways-title">Key takeaways</h3>
+    <ul class="blog-takeaways-list"><li>Family trips expose weak AI planning fast because transfer friction, nap windows, room setup, and ticket timing all compound across cities.</li>
+<li>A useful AI trip planner should structure the trip around recovery blocks, realistic travel days, and booking continuity instead of attraction volume.</li>
+<li>Alfred can support family planning with route validation, sample destination pages, and booking-ready next steps for trips such as Orlando and Bali.</li></ul>
+  </aside>
+            <div class="blog-article-body"><p>A family trip can look efficient on paper and still fail in real life.</p>
+<p>That usually happens when a plan treats parents, kids, luggage, airport timing, and hotel changes as minor details instead of the core job. A generic AI tool might suggest a clean list of cities and attractions. The harder part is building a route that survives early flights, midday crashes, room handoffs, and the reality that one delayed transfer can disrupt the whole day.</p>
+<p>That is where a stronger <strong><a href="../ai-trip-planner/index.html">AI Trip Planner</a></strong> should help. It should not just answer “where should we go?” It should help answer “what pace will still work on day four?”</p>
+<h2>Why Family Travel Breaks Weak Itineraries So Quickly</h2>
+<p>Family trips create compounding friction:</p>
+<ul>
+<li><strong>arrival days are slower</strong> because bags, transport, snacks, and check-in all take longer</li>
+<li><strong>energy levels diverge</strong> between adults, toddlers, teens, and grandparents</li>
+<li><strong>room setup matters</strong> because adjoining rooms, bedding needs, and walkability affect the rest of the stay</li>
+<li><strong>tickets and bookings interact</strong> because one late arrival can wreck a timed activity or dinner reservation</li>
+<li><strong>multi-city moves cost more</strong> when every transfer burns time and patience</li>
+</ul>
+<p>A couple on a city break can improvise around bad sequencing. A family moving across multiple stops usually pays for it immediately.</p>
+<h2>Start With the Family Brief Before the Destination List</h2>
+<p>Before asking AI for an itinerary, define the operating constraints.</p>
+<p>A useful family brief should cover:</p>
+<ol>
+<li><strong>Ages and mobility</strong> — stroller, car seat, walking tolerance, or accessibility needs</li>
+<li><strong>Morning vs evening energy</strong> — who is freshest when, and how late the group can reasonably stay out</li>
+<li><strong>Luggage load</strong> — carry-on only, checked bags, sports gear, or baby equipment</li>
+<li><strong>Must-do moments</strong> — the one or two experiences that matter most in each stop</li>
+<li><strong>Non-negotiable recovery time</strong> — naps, pool breaks, quiet afternoons, or slow mornings after travel</li>
+</ol>
+<p>This matters because AI gets better when the trip brief is concrete. If the prompt is vague, the itinerary usually becomes too adult-paced, too attraction-dense, or too optimistic about transport.</p>
+<p>If you want a clean overview of Alfred’s planning model before going deeper, the <strong><a href="../faq.html">FAQ</a></strong> explains how family profiles, itinerary validation, and booking partners fit together.</p>
+<h2>Build Around Transfer Friction, Not Attraction Volume</h2>
+<p>The biggest family-planning mistake is counting sights without pricing the travel day between them.</p>
+<p>A better rule is to treat each city change as the main event for that block. Then layer the rest around it.</p>
+<h3>What that looks like in practice</h3>
+<ul>
+<li><strong>Arrival day:</strong> one soft landing activity, not a full sightseeing sprint</li>
+<li><strong>Transfer day:</strong> one neighborhood or one anchor experience after check-in, not three scattered stops</li>
+<li><strong>Full day:</strong> one major attraction plus one lighter supporting block</li>
+<li><strong>Departure day:</strong> protect airport or station buffers first, then add anything optional</li>
+</ul>
+<p>This is why route-aware planning matters more for families than for solo travelers. The trip does not fail because the museum was bad. It fails because the plan assumed the family could land, transfer, check in, eat, and cross town again without losing momentum.</p>
+<h2>Choose One Anchor Per City</h2>
+<p>Multi-city family trips become easier when each stop has a simple identity.</p>
+<p>Instead of trying to “do everything,” define one anchor for each place:</p>
+<ul>
+<li><strong>Orlando:</strong> theme-park core with built-in rest and weather buffers</li>
+<li><strong>Bali:</strong> split between one coastal base and one inland base, not endless hotel hopping</li>
+<li><strong>Paris:</strong> one museum day, one neighborhood day, one flexible food-and-park day</li>
+</ul>
+<p>That gives AI a stronger frame for sequencing.</p>
+<p>It also makes internal trade-offs clearer. If the city anchor is a park-heavy day, you know the night before should stay light. If the anchor is a transfer plus evening food walk, you know not to book the hardest museum morning right after it.</p>
+<p>For Alfred examples, review the <strong><a href="../itineraries/orlando.html">Orlando itinerary</a></strong> and <strong><a href="../itineraries/bali.html">Bali itinerary</a></strong> after this guide. Both show how a destination page can start with pace and logistics instead of an unfiltered list of things to do.</p>
+<h2>Protect Recovery Blocks on Purpose</h2>
+<p>Families do not need more enthusiasm from AI. They need permission to leave space.</p>
+<p>Recovery blocks are not dead time. They are the reason the rest of the trip works.</p>
+<p>Useful recovery blocks include:</p>
+<ul>
+<li>hotel pool or playground time after a long morning</li>
+<li>a late breakfast after an arrival day</li>
+<li>one low-decision meal close to the hotel</li>
+<li>one evening with nothing ticketed</li>
+<li>a half day between two intense city or theme-park blocks</li>
+</ul>
+<p>This is also where creator-style travel content is useful as inspiration but not enough on its own. Beautiful destination roundups can help with ideas, but a family still needs the execution layer: when to slow down, what to cluster, and what to skip.</p>
+<h2>Keep Booking Continuity Visible</h2>
+<p>A family itinerary stops being useful when the planning layer and booking layer drift apart.</p>
+<p>As the route firms up, keep these questions visible:</p>
+<ul>
+<li>Are the hotel locations still right for the daily plan?</li>
+<li>Do room types match the family composition?</li>
+<li>Are seat assignments or rail reservations needed before the trip sells out?</li>
+<li>Are long transfer days followed by low-friction evenings?</li>
+<li>Does the timed ticket require a different breakfast, taxi, or wake-up window than the draft assumed?</li>
+</ul>
+<p>This is one reason Alfred’s positioning should stay execution-first. The goal is not to generate more ideas. The goal is to move from ideas to a plan that is still coherent when bookings start locking in.</p>
+<h2>Use Examples, Then Adapt</h2>
+<p>Families often plan faster when they start from a route pattern instead of a blank page.</p>
+<p>If your trip involves a resort-plus-activities rhythm, the <strong><a href="bali-for-families.html">Bali family guide</a></strong> is a useful example of how to think about drive times, rest windows, and child-friendly pacing. If your trip is park-heavy or ticket-heavy, the <strong><a href="../itineraries/orlando.html">Orlando itinerary</a></strong> shows how to protect the group from heat, overstacking, and departure-day chaos.</p>
+<p>Those examples should not be copied city for city. They are useful because they show a structure:</p>
+<ul>
+<li>one clear base</li>
+<li>one daily anchor</li>
+<li>protected rest windows</li>
+<li>transfer logic that matches the group</li>
+<li>enough flexibility to recover when the day shifts</li>
+</ul>
+<h2>Final Thought</h2>
+<p>The best family trips rarely feel the most ambitious on paper. They feel the most survivable once the trip is underway.</p>
+<p>That is the standard a strong AI itinerary should meet. It should help a family move across cities without losing the booking thread, the recovery time, or the energy to enjoy the reason they traveled in the first place.</p>
+<h2>FAQ: Planning a Family Trip With AI</h2>
+<h3>Why are family trips harder for generic AI planners?</h3>
+<p>Because the trip has more interacting constraints. Kids, bags, rooms, transport timing, and group energy all affect whether the route is realistic.</p>
+<h3>What should a family decide before asking AI to build the route?</h3>
+<p>Set the brief first: ages, pace, mobility needs, luggage load, must-do moments, and what a successful day actually feels like for the group.</p>
+<h3>How many major activities should a family plan per day?</h3>
+<p>Usually one anchor activity plus one lighter block. More than that often creates hidden transport and fatigue costs, especially across multiple cities.</p>
+<h3>Where should I go next after reading this?</h3>
+<p>Start with Alfred’s <strong><a href="../ai-trip-planner/index.html">AI Trip Planner</a></strong> for the validation overview, then review the <strong><a href="../itineraries/orlando.html">Orlando itinerary</a></strong>, <strong><a href="../itineraries/bali.html">Bali itinerary</a></strong>, and <strong><a href="../faq.html">FAQ</a></strong> for practical next steps.</p>
+</div>
+        </article>
+    </main>
+
+    <footer>
+        <div class="footer-content">
+            <div class="footer-column"><h3>Company</h3><ul class="footer-links"><li><a href="../about.html">About Us</a></li><li><a href="../about.html#mission">Our Mission</a></li><li><a href="../about.html#team">Our Team</a></li><li><a href="../index.html#features">Features</a></li></ul></div>
+            <div class="footer-column"><h3>Features</h3><ul class="footer-links"><li><a href="../products.html">Our Features</a></li><li><a href="../itineraries/index.html">Itineraries</a></li><li><a href="../compare/index.html">Compare</a></li><li><a href="index.html">Blog</a></li><li><a href="../faq.html">FAQ</a></li></ul></div>
+            <div class="footer-column"><h3>Solutions</h3><ul class="footer-links"><li><a href="../ai-trip-planner/index.html">AI Trip Planner</a></li><li><a href="../ai-travel-planner/index.html">AI Travel Planner</a></li><li><a href="../ai-holiday-planner/index.html">AI Holiday Planner</a></li></ul></div>
+            <div class="footer-column"><h3>Support</h3><ul class="footer-links"><li><a href="../delete-account.html">Support Center</a></li><li><a href="../index.html#contact">Contact Us</a></li><li><a href="../faq.html">Help & FAQ</a></li></ul></div>
+            <div class="footer-column"><h3>Legal</h3><ul class="footer-links"><li><a href="../terms.html">Terms & Conditions</a></li><li><a href="../terms.html#privacy">Privacy Policy</a></li><li><a href="../prize-tc.html">Prize Terms</a></li></ul></div>
+        </div>
+        <div class="footer-bottom"><p>&copy; 2026 Alfred Travel Tech Pty Ltd. All rights reserved.</p></div>
+    </footer>
+    <div id="cookies-banner" class="cookies-banner"><div class="cookies-content"><div class="cookies-text"><h3>🍪 We use cookies</h3><p>We use cookies and similar technologies. <a href="../terms.html#privacy" class="cookies-link">Privacy Policy</a> · <a href="#" class="cookies-link" id="cookie-settings">Cookie Settings</a>.</p></div><div class="cookies-buttons"><button id="accept-all-cookies" class="btn btn-primary">Accept All</button><button id="reject-cookies" class="btn btn-secondary">Reject All</button></div></div></div>
+    <script src="../js/main.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -257,7 +257,7 @@
                     <div class="how-card-text">
                         <div class="step-number">1</div>
                         <h3>Create Your Family Profile</h3>
-                        <p>Set up your family's travel preferences and requirements</p>
+                        <p>Set up your family's travel preferences and requirements, then use our <a href="blog/multi-city-family-trip-ai-guide.html">multi-city family AI planning guide</a> to pressure-test pacing, room logic, and transfer days.</p>
                     </div>
                     <div class="how-card-image">
                         <img src="images/Family Profile.jpeg" alt="Alfred AI mobile app showing family profile setup for multi-city travel planning" class="step-image">

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -12,6 +12,7 @@
   <url><loc>https://www.alfredtravel.io/terms.html</loc><changefreq>monthly</changefreq><priority>0.5</priority></url>
   <url><loc>https://www.alfredtravel.io/delete-account.html</loc><changefreq>monthly</changefreq><priority>0.5</priority></url>
   <url><loc>https://www.alfredtravel.io/prize-tc.html</loc><changefreq>monthly</changefreq><priority>0.5</priority></url>
+  <url><loc>https://www.alfredtravel.io/blog/multi-city-family-trip-ai-guide.html</loc><lastmod>2026-06-13</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
   <url><loc>https://www.alfredtravel.io/blog/india-travel-ai-delhi-execution.html</loc><lastmod>2026-06-11</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
   <url><loc>https://www.alfredtravel.io/blog/skift-b2a-ai-agents-travel-alfred-aio.html</loc><lastmod>2026-05-25</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
   <url><loc>https://www.alfredtravel.io/blog/skift-india-voice-first-travel-alfred.html</loc><lastmod>2026-05-24</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>


### PR DESCRIPTION
## Summary
Add one original family-planning blog guide plus lightweight internal links from Alfred’s broadest traffic pages into that guide. This run **updated the existing ga-growth PR** instead of opening a duplicate, because the current opportunity is the same family-planning content cluster.

## Analytics observations
GA4 reports snapshot (last 90 days, inspected via live CDP session):
- **Active users:** 844
- **New users:** 835
- **Average engagement time per active user:** 25s
- **Event count:** 7k
- **Top pages / screens:**
  - `Alfred Travel: AI-powered travel planning you can actually book` — **837 views**, 461 active users, 3.3k events, **52.4% bounce rate**
  - `AI Trip Planner, AI Travel Planner & AI Holiday Planner | Alfred` — **552 views**, 344 active users, 2.3k events, **49.3% bounce rate**
  - `Alfred | #1 AI Trip Planner for Multi-City Logistical Validation` — 130 views, 3 active users, 370 events, 33.3% bounce rate
  - `Our Features | Superior AI Travel Logistics...` — 63 views, 44 active users, 211 events, **17.4% bounce rate**
  - `FAQ | Superior AI Travel Logistics...` — 48 views, 26 active users, 160 events, **14.3% bounce rate**
- **Notable pattern:** the broad homepage and AI Trip Planner landing page attract the most traffic but bounce materially harder than deeper utility pages like Features and FAQ.
- **Acquisition signals:**
  - `google / organic` — 169 active users, 256 sessions
  - `chatgpt.com` combined — 26 active users, 32 sessions

## Why this opportunity was chosen
The broadest landing pages already capture search and AI-discovery demand, but their weaker engagement suggests visitors need a clearer path into practical, specific planning help. A family-focused multi-city guide is already the active content theme on this PR, so the highest-confidence follow-up is to surface that guide directly from the homepage rather than start a redundant second family-planning PR.

## Google AI-optimization guidance used
Reviewed: `https://developers.google.com/search/docs/fundamentals/ai-optimization-guide`

Applied guidance:
- Create **valuable, non-commodity, people-first content** with original planning utility.
- Use **clear structure and headings** so content is easy for readers and AI retrieval systems to interpret.
- Improve discoverability with **useful internal links** from broad landing pages into deeper answer-style content.
- Preserve **crawlable, indexable HTML** and avoid unsupported tactics like AI-only markup files, keyword-stuffing, or content chunking for its own sake.

## External sources reviewed this run and how they informed the change
1. **Skift** (`https://skift.com/` homepage)
   - Reviewed visible headlines including **"Travelport Launches TripServices to Power AI Travel Booking"**.
   - Influence: reinforced the need to connect planning intent with execution-ready next steps, not just publish generic inspiration copy.
2. **PhocusWire** (`https://www.phocuswire.com/` homepage)
   - Reviewed visible headlines including **"AI is the next productivity shock: Can travel reap the gains?"**, **"Cendyn launches Wayfinder to help hotels avoid 'OTA 2.0'"**, and **"UK investigates Ryanair over family seat fees"**.
   - Influence: supported a family-friction-aware content angle centered on practical execution details such as seat logic, room setup, pacing, and booking continuity.
3. **Nomadic Matt** (`https://www.nomadicmatt.com/` homepage)
   - Reviewed visible planning resources including **"How to Plan Your Trip"**, **"16 Steps for Planning a Trip"**, and **"Family & Senior Travel"**.
   - Influence: reinforced the value of surfacing step-based family planning guidance early in the user journey.

## What changed
Existing PR changes retained:
- Added `_posts/multi-city-family-trip-ai-guide.md`
- Added generated `blog/multi-city-family-trip-ai-guide.html`
- Added a contextual internal-link paragraph on `ai-trip-planner/index.html`
- Regenerated `blog/index.html` and `sitemap.xml`

This run added:
- A direct homepage internal link from the **Create Your Family Profile** step to the family-planning guide on `index.html`

## Why this may improve traffic / viewership / engagement / AI-search visibility
- Adds a stronger **internal route from the highest-view, highest-bounce page** into specific family-planning content.
- Gives Google Search AI features and chat-style retrieval systems a clearer, more useful content path around Alfred’s family-travel use case.
- Improves the chance that broad-intent visitors land on a page that better matches deeper family logistics questions.
- Preserves the current site layout while increasing topical depth and navigational usefulness.

## Files changed
- `index.html`
- `ai-trip-planner/index.html`
- `_posts/multi-city-family-trip-ai-guide.md`
- `blog/multi-city-family-trip-ai-guide.html`
- `blog/index.html`
- `sitemap.xml`

## Validation commands and outcomes
- `npm run build:blog` ✅
- `npm run build:itineraries` ✅
- `npm run build:compare` ✅
- `npm test` not run because `package.json` currently has no `test` script.
- Responsive verification via CDP on the local built homepage:
  - **390px mobile:** `scrollWidth == clientWidth`, no horizontal overflow; homepage family-profile card contains the new guide link
  - **1024px tablet/desktop:** `scrollWidth == clientWidth`, no horizontal overflow

## Layout note
The existing site layout was intentionally preserved. This PR only adds content and lightweight internal-linking improvements.

## Branching note
- This PR was created and updated by the agent.
- Source branch: `agent/ga-growth-20260613-0903`
- Base branch: `gh-pages`
- This work was branched from `gh-pages` and targets `gh-pages`.
