### PR TITLE
[AGENT] feat(internal-links): widen ai trip planning intent paths

### DIFF
--- a/ai-trip-planner/index.html
+++ b/ai-trip-planner/index.html
@@ -145,6 +145,7 @@
         <section class="landing-section">
             <h2>Keep researching without leaving Alfred</h2>
             <p>Analytics shows this AI Trip Planner page brings strong traffic but weaker engagement than Alfred&apos;s feature and FAQ pages. These next steps help travelers answer the practical questions they usually have before downloading or booking.</p>
+            <p>If you are still comparing options, start with our <a href="../blog/how-to-plan-a-trip-with-ai-without-generic-itineraries.html">practical AI trip planning checklist</a> to pressure-test route order, transfer buffers, hotel fit, and pacing before you commit.</p>
             <div class="landing-grid">
                 <div class="landing-card">
                     <h3>See the product features behind route validation</h3>

--- a/ai-trip-planner/index.html
+++ b/ai-trip-planner/index.html
@@ -145,7 +145,7 @@
         <section class="landing-section">
             <h2>Keep researching without leaving Alfred</h2>
             <p>Analytics shows this AI Trip Planner page brings strong traffic but weaker engagement than Alfred&apos;s feature and FAQ pages. These next steps help travelers answer the practical questions they usually have before downloading or booking.</p>
-            <p>If you are still comparing options, start with our <a href="../blog/how-to-plan-a-trip-with-ai-without-generic-itineraries.html">practical AI trip planning checklist</a> to pressure-test route order, transfer buffers, hotel fit, and pacing before you commit.</p>
+            <p>If you are still comparing options, start with our <a href="../blog/how-to-plan-a-trip-with-ai-without-generic-itineraries.html">practical AI trip planning checklist</a> to pressure-test route order, then use the <a href="../blog/ai-hotel-vs-airbnb-logic.html">hotel-vs-Airbnb decision guide</a> for stay fit and the <a href="../blog/bali-for-families.html">family pacing guide</a> when timing or space gets fragile.</p>
             <div class="landing-grid">
                 <div class="landing-card">
                     <h3>See the product features behind route validation</h3>

--- a/blog/ai-hotel-vs-airbnb-logic.html
+++ b/blog/ai-hotel-vs-airbnb-logic.html
@@ -4,7 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>AI Hotel vs Airbnb Logic: When to Book Which (And Why It's a Logistical Question) | Alfred Travel Blog</title>
-    <meta name="description" content="Hotel vs Airbnb isn't vibes—it's location, check-in windows, and trip structure. Alfred's logic, not guesswork.">
+    <meta name="description" content="A practical hotel-vs-Airbnb decision guide for AI trip planning. Learn when hotels win, when Airbnb works better, what to validate before booking, and how stay choice changes with late arrivals, families, remote work, and multi-city trips.">
+    <meta name="keywords" content="hotel vs Airbnb, AI travel planning, accommodation decision guide, multi-city trip planning, family travel accommodation, remote work travel, Alfred Travel">
     <link rel="canonical" href="https://www.alfredtravel.io/blog/ai-hotel-vs-airbnb-logic.html">
         <link rel="icon" type="image/png" sizes="16x16" href="../images/brand/favicon-16.png">
     <link rel="icon" type="image/png" sizes="32x32" href="../images/brand/favicon-32.png">
@@ -40,8 +41,8 @@
   "@context": "https://schema.org",
   "@type": "BlogPosting",
   "headline": "AI Hotel vs Airbnb Logic: When to Book Which (And Why It's a Logistical Question)",
-  "description": "Hotel vs Airbnb isn't vibes—it's location, check-in windows, and trip structure. Alfred's logic, not guesswork.",
-  "datePublished": "2025-12-16",
+  "description": "A practical hotel-vs-Airbnb decision guide for AI trip planning. Learn when hotels win, when Airbnb works better, what to validate before booking, and how stay choice changes with late arrivals, families, remote work, and multi-city trips.",
+  "datePublished": "2026-06-20",
   "author": {
     "@type": "Person",
     "name": "Alfred Team"
@@ -74,8 +75,8 @@
     {
       "@type": "ListItem",
       "position": 3,
-      "name": "AIO Insights",
-      "item": "https://www.alfredtravel.io/blog/?category=AIO%20Insights"
+      "name": "AI Travel",
+      "item": "https://www.alfredtravel.io/blog/?category=AI%20Travel"
     },
     {
       "@type": "ListItem",
@@ -85,6 +86,9 @@
     }
   ]
 }
+    </script>
+    <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"Is a hotel or Airbnb better for a short city break?","acceptedAnswer":{"@type":"Answer","text":"Hotels usually win on short trips because check-in is simpler, arrival friction is lower, and the cost of a poor location or awkward host timing is harder to recover from when you only have a few days."}},{"@type":"Question","name":"When does Airbnb make more sense than a hotel?","acceptedAnswer":{"@type":"Answer","text":"Airbnb usually makes more sense when you need more space, laundry, kitchen access, or a quieter residential setup for a longer stay, especially for families or slower-paced trips."}},{"@type":"Question","name":"Should I use the same stay type for every city in a multi-city trip?","acceptedAnswer":{"@type":"Answer","text":"No. The right stay type can change by stop. A hotel may be better near an airport or station on a transit-heavy leg, while an apartment may work better in a longer destination stay."}},{"@type":"Question","name":"What should AI validate before recommending a hotel or Airbnb?","acceptedAnswer":{"@type":"Answer","text":"It should validate arrival time, check-in flexibility, luggage friction, transport links, neighbourhood fit, cancellation terms, and whether the stay supports the next leg of the itinerary."}},{"@type":"Question","name":"How does family travel change the hotel-vs-Airbnb decision?","acceptedAnswer":{"@type":"Answer","text":"Family travel raises the value of extra space, kitchens, laundry, and predictable quiet time, but it also makes location and access more important. A spacious apartment that adds long daily transfers can still be the wrong choice."}}]}
     </script>
 </head>
 <body class="blog-page">
@@ -109,56 +113,151 @@
     </header>
     <main class="blog-main">
         <article class="blog-article">
-            <nav class="blog-breadcrumb" aria-label="Breadcrumb">Home &rarr; <a href="index.html">Blog</a> &rarr; AIO Insights &rarr; <span>AI Hotel vs Airbnb Logic: When to Book Which (And Why It's a Logistical Question)</span></nav>
+            <nav class="blog-breadcrumb" aria-label="Breadcrumb">Home &rarr; <a href="index.html">Blog</a> &rarr; AI Travel &rarr; <span>AI Hotel vs Airbnb Logic: When to Book Which (And Why It's a Logistical Question)</span></nav>
             <header class="blog-article-header">
-                <p class="blog-meta"><time datetime="2025-12-16">2025-12-16</time> &middot; Alfred Team &middot; AIO Insights</p>
+                <p class="blog-meta"><time datetime="2026-06-20">2026-06-20</time> &middot; Alfred Team &middot; AI Travel</p>
                 <h1 class="blog-article-title">AI Hotel vs Airbnb Logic: When to Book Which (And Why It's a Logistical Question)</h1>
             </header>
             <aside class="blog-takeaways-callout" aria-label="Key takeaways">
     <h3 class="blog-takeaways-title">Key takeaways</h3>
-    <ul class="blog-takeaways-list"><li>Alfred treats accommodation as part of itinerary logic: location, check-in, and transit to next leg.</li>
-<li>Integrated global booking (Trip.com, Expedia, etc.) keeps plan and book in one flow—no affiliate hop.</li>
-<li>Country-locked or static planners can't optimize stay type by trip structure; Alfred can.</li></ul>
+    <ul class="blog-takeaways-list"><li>Stay choice should follow trip structure: arrival time, departure pressure, neighbourhood fit, transfer friction, and how many times you are moving.</li>
+<li>Hotels usually win for short stays, late arrivals, early departures, and multi-city trips where reliability matters more than extra space.</li>
+<li>Airbnb can win for longer stays, family routines, laundry, kitchen access, and split schedules—but only when the location and host rules still fit the route.</li>
+<li>A useful AI travel planner should validate accommodation against the itinerary, not treat booking as a separate afterthought.</li></ul>
   </aside>
-            <div class="blog-article-body"><p>Hotel vs Airbnb isn’t a personality test—it’s <strong>logistics</strong>: check-in times, location relative to your first/last activity, and whether you’re doing one city or five. <strong>Alfred Travel</strong> models it that way: your itinerary’s <strong>transit validation</strong> and <strong>activity gating</strong> inform where you stay and when, so the “AI hotel vs Airbnb” question gets an answer that fits the trip.</p>
-<h2>Comparison Table: How We Reason About Stay</h2>
+            <div class="blog-article-body"><p>Hotel vs Airbnb is not a personality test. It is a <strong>trip-structure decision</strong>.</p>
+<p>The right stay depends on what the rest of the itinerary is trying to do: when you land, how often you move, whether you need laundry or kitchen access, how fragile the pacing is, and how much friction your group can tolerate.</p>
+<p>That is why broad advice like “Airbnb is more authentic” or “hotels are easier” is only partly useful. A stay that looks perfect in isolation can still make the whole trip worse if it adds a bad transfer, a risky late check-in, or a neighbourhood that fights the rest of your plan.</p>
+<p>If you are using AI to plan a trip, accommodation should be validated the same way you validate route order, airport buffers, and travel-day density.</p>
+<h2>Start with the shape of the trip, not the property type</h2>
+<p>Before you compare listings, define the conditions that change the answer:</p>
+<ul>
+<li><strong>How many nights are you staying?</strong></li>
+<li><strong>Are you moving city-to-city or staying put?</strong></li>
+<li><strong>Do you land late or leave early?</strong></li>
+<li><strong>Do you need laundry, a kitchen, or separate sleeping space?</strong></li>
+<li><strong>Will your day plan depend on a station, beach, meeting point, or walkable centre?</strong></li>
+<li><strong>How expensive is a bad check-in experience for this trip?</strong></li>
+</ul>
+<p>A two-night stop after a late flight is a very different accommodation problem from a seven-night family base or a month-long remote-work stay.</p>
+<h2>The fastest hotel-vs-Airbnb decision table</h2>
 <table>
 <thead>
 <tr>
-<th>Factor</th>
-<th>Vibes / generic advice</th>
-<th>Alfred Travel</th>
+<th>Trip condition</th>
+<th>Hotel usually wins when...</th>
+<th>Airbnb usually wins when...</th>
 </tr>
 </thead>
 <tbody><tr>
-<td>Check-in vs. arrival</td>
-<td>Ignored</td>
-<td>Validated: late flight → hotel with 24h reception or adjusted plan</td>
+<td><strong>Arrival and check-in</strong></td>
+<td>You land late, need 24-hour reception, or cannot afford host-message uncertainty</td>
+<td>You can arrive in daylight and the host process is predictable</td>
 </tr>
 <tr>
-<td>Location</td>
-<td>“Central is best”</td>
-<td>Tied to your validated transit (e.g. station, first day’s zone)</td>
+<td><strong>Length of stay</strong></td>
+<td>It is a short break and convenience matters more than extra space</td>
+<td>You are staying long enough to use the kitchen, laundry, or living area</td>
 </tr>
 <tr>
-<td>Multi-city</td>
-<td>Same rule everywhere</td>
-<td>Hotel vs Airbnb can vary by city in one itinerary</td>
+<td><strong>Trip style</strong></td>
+<td>You are moving every few nights and need low-friction transitions</td>
+<td>You are anchoring in one neighbourhood and want a residential base</td>
 </tr>
 <tr>
-<td>Booking</td>
-<td>Links out to OTAs</td>
-<td>Integrated global booking; plan and book in one place</td>
+<td><strong>Group setup</strong></td>
+<td>Everyone can share one or two standard rooms easily</td>
+<td>You need separate bedrooms, naps, or split schedules</td>
+</tr>
+<tr>
+<td><strong>Location logic</strong></td>
+<td>You need to be close to a station, airport bus, or early activity zone</td>
+<td>A residential location improves the stay without breaking transport</td>
+</tr>
+<tr>
+<td><strong>Risk tolerance</strong></td>
+<td>You want clearer cancellation, storage, support, and backup options</td>
+<td>You are comfortable trading some certainty for space or local fit</td>
 </tr>
 </tbody></table>
-<p>We <strong>validate</strong> that your Day 1 landing and Day 5 early flight are compatible with your stay type and location—so the recommendation is <strong>logistical</strong>, not generic.</p>
-<h2>Why Alfred Wins on This</h2>
+<p>That is the core rule: <strong>the more brittle the trip, the more hotels tend to win. The longer and more settled the trip, the stronger the Airbnb case becomes.</strong></p>
+<h2>When hotels are the safer choice</h2>
+<p>Hotels usually outperform Airbnb when the trip has very little slack.</p>
+<h3>1) Late arrivals or early departures</h3>
+<p>If you land after dinner, arrive from a delayed flight, or leave before sunrise, a staffed hotel is often the lower-risk choice. You are not relying on a host handoff, a self-check-in process that fails at the wrong moment, or messages arriving while you are still in transit.</p>
+<h3>2) Short stays with tight sightseeing windows</h3>
+<p>On a two- or three-night city break, convenience compounds fast. Easy luggage storage, predictable check-in, and a walkable or transit-linked location usually matter more than having a full kitchen.</p>
+<h3>3) Transit-heavy multi-city trips</h3>
+<p>When you are changing cities often, every stay transition has a cost. Hotels are often better for these stops because they reduce friction between station arrival, bag drop, sleep, and the next departure. If your trip needs a strong route spine first, start with Alfred’s <a href="../ai-trip-planner/index.html">AI Trip Planner</a> or the <a href="../blog/how-to-plan-a-trip-with-ai-without-generic-itineraries.html">AI trip planning checklist</a>.</p>
+<h3>4) Work trips or fixed schedules</h3>
+<p>If you must be online at a specific time, cannot risk Wi-Fi ambiguity, or need a front desk to solve problems quickly, hotels usually provide a more predictable operating environment.</p>
+<h3>5) Loyalty or bundled-value trips</h3>
+<p>Breakfast, elite perks, points earnings, late checkout, and easy same-day support can make a hotel the better economic decision even when the nightly rate is higher on paper.</p>
+<h2>When Airbnb can be the better choice</h2>
+<p>Airbnb usually starts winning when the stay itself is part of how the trip works.</p>
+<h3>1) Longer stays where space matters</h3>
+<p>If you are staying five nights or more, space, kitchens, and laundry can change the day-to-day economics of the trip. That is especially true when you want slower mornings, groceries, or a place to recover after long sightseeing days.</p>
+<h3>2) Families and mixed-energy groups</h3>
+<p>Families often need a different rhythm from couples or solo travellers. Separate sleeping space, snack access, and the ability to reset midday can outweigh hotel convenience. But the location still has to support the trip. A cheaper apartment thirty minutes from everything can erase the value of the extra space. If this is your main constraint, cross-check the plan against our <a href="../blog/bali-for-families.html">family pacing guide</a>.</p>
+<h3>3) Residential neighbourhood stays</h3>
+<p>Sometimes the goal is not to be in the busiest core but to settle into one district for a week, live closer to parks or local food, and slow the schedule down. Airbnb can work well here when the route is stable and daily transport still makes sense.</p>
+<h3>4) Remote work or split-day travel</h3>
+<p>A living area, table, kitchen, and quieter routine can matter more than daily housekeeping when you are working part of the day or balancing different traveler schedules.</p>
+<h2>The red flags that should flip your decision</h2>
+<p>Even if a listing looks attractive, these warning signs usually mean you should reconsider the stay type or the neighbourhood:</p>
 <ul>
-<li><strong>One itinerary:</strong> Accommodation is part of the same plan as trains, activities, and transfers.</li>
-<li><strong>Integrated booking:</strong> No “here’s a link, good luck”—we keep you in the Alfred flow.</li>
-<li><strong>Multi-city:</strong> Different cities can get different stay logic (e.g. hotel in Paris, Airbnb in Lyon) in one validated plan.</li>
+<li><strong>The airport or station transfer is awkward at the hour you arrive</strong></li>
+<li><strong>Check-in depends on a narrow host window</strong></li>
+<li><strong>The “cheap” option adds long daily backtracking</strong></li>
+<li><strong>The first or last day becomes transit-heavy just because of the stay location</strong></li>
+<li><strong>Laundry or kitchen benefits look good on paper but will not actually be used</strong></li>
+<li><strong>You are carrying baggage, strollers, or work gear through stairs or long walks</strong></li>
+<li><strong>You need predictable support if something slips</strong></li>
 </ul>
-<p>Stop planning, start traveling. Open this itinerary in the <a href="https://www.alfredtravel.io">Alfred App</a>.</p>
+<p>If one of those red flags appears, the stay is no longer just a price comparison. It is a route-risk problem.</p>
+<h2>Use different stay logic for different cities</h2>
+<p>One of the most common planning mistakes is forcing the same accommodation rule across the whole trip.</p>
+<p>A better approach is to let each stop answer a different question:</p>
+<ul>
+<li><strong>Arrival or departure city:</strong> hotel near the transport spine</li>
+<li><strong>Longer destination stay:</strong> Airbnb if space and routine meaningfully improve the trip</li>
+<li><strong>One-night connector stop:</strong> hotel for low-friction sleep and bag handling</li>
+<li><strong>Family beach or resort leg:</strong> whichever option best supports rest, laundry, and meal flexibility without isolating you from the plan</li>
+</ul>
+<p>That is often the real answer to hotel vs Airbnb: <strong>not one or the other, but which one fits each leg best</strong>.</p>
+<h2>What to ask AI before you book</h2>
+<p>A useful planner should not stop at “here are three properties.” It should explain the trade-offs.</p>
+<p>Use prompts like these:</p>
+<blockquote>
+<p>Compare hotel vs Airbnb for this trip based on arrival time, check-in friction, walking distance to the main activity zone, luggage burden, and how stable the next transfer day is.</p>
+</blockquote>
+<blockquote>
+<p>For each city, tell me whether a hotel or apartment reduces the most friction, and explain which one becomes risky if the arrival is delayed by two hours.</p>
+</blockquote>
+<blockquote>
+<p>Rewrite this accommodation plan assuming I am traveling with children / remote work hours / one early flight / one late train arrival.</p>
+</blockquote>
+<p>The answer should discuss <strong>timing, neighbourhood fit, and operational risk</strong>—not just “hotels are convenient” or “Airbnbs are homier.”</p>
+<h2>A quick validation checklist before paying</h2>
+<p>Before you book either stay type, pressure-test these points:</p>
+<ol>
+<li><p><strong>Arrival works in the real world.</strong><br>If your flight slips, can you still check in safely?</p>
+</li>
+<li><p><strong>Location supports the first and last day.</strong><br>Not just the average day.</p>
+</li>
+<li><p><strong>The stay reduces friction somewhere important.</strong><br>Space, support, transport, laundry, or rest.</p>
+</li>
+<li><p><strong>The cancellation terms match the risk.</strong><br>Flexibility matters more on brittle routes.</p>
+</li>
+<li><p><strong>The next transfer still works.</strong><br>Especially on early trains, ferries, or flights.</p>
+</li>
+<li><p><strong>The choice matches the group, not just the spreadsheet.</strong><br>Families, couples, solo travellers, and work trips use space differently.</p>
+</li>
+</ol>
+<h2>Final thought</h2>
+<p>The right stay is the one that makes the whole itinerary easier to execute.</p>
+<p>For some trips that means a hotel with predictable support near the station. For others it means an apartment with laundry, kitchen access, and enough room for the trip to breathe. The winning choice is the one that fits the route, the timing, and the group—not the one that sounds best in generic travel advice.</p>
+<p>If you are still comparing route structure, start with the <a href="../blog/how-to-plan-a-trip-with-ai-without-generic-itineraries.html">AI trip planning checklist</a>. If family timing is the real blocker, use the <a href="../blog/bali-for-families.html">family pacing guide</a>. And if you want to validate all of it inside one planning flow, start with Alfred’s <a href="../ai-trip-planner/index.html">AI Trip Planner</a>.</p>
 </div>
         </article>
     </main>

--- a/blog/how-to-plan-a-trip-with-ai-without-generic-itineraries.html
+++ b/blog/how-to-plan-a-trip-with-ai-without-generic-itineraries.html
@@ -88,7 +88,7 @@
 }
     </script>
     <script type="application/ld+json">
-{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"How should I use AI to plan a trip?","acceptedAnswer":{"@type":"Answer","text":"Use AI to build and compare route options, then validate timing, hotel fit, and pacing before booking. The best results come from giving the model real constraints instead of broad prompts."}},{"@type":"Question","name":"Why do AI trip itineraries feel generic?","acceptedAnswer":{"@type":"Answer","text":"They often start from attraction lists instead of traveller constraints. That leads to schedules that look polished but ignore transfer friction, energy levels, and booking realities."}},{"@type":"Question","name":"What should an AI travel planner validate before booking?","acceptedAnswer":{"@type":"Answer","text":"At minimum: route order, airport or rail transfer windows, hotel location relative to your day plan, day density, and whether a long-haul or red-eye requires recovery time."}},{"@type":"Question","name":"What details should I give AI before asking for an itinerary?","acceptedAnswer":{"@type":"Answer","text":"Include dates, arrival and departure cities, number of stops, transfer tolerance, budget shape, accommodation preferences, and any pace constraints such as travelling with children or needing recovery time after long-haul flights."}},{"@type":"Question","name":"Can AI plan a multi-city trip well?","acceptedAnswer":{"@type":"Answer","text":"Yes, but only when the planner checks sequencing and buffers. Multi-city trips break when each leg is treated as an isolated suggestion rather than part of one connected route."}}]}
+{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"How should I use AI to plan a trip?","acceptedAnswer":{"@type":"Answer","text":"Use AI to build and compare route options, then validate timing, hotel fit, and pacing before booking. The best results come from giving the model real constraints instead of broad prompts."}},{"@type":"Question","name":"Why do AI trip itineraries feel generic?","acceptedAnswer":{"@type":"Answer","text":"They often start from attraction lists instead of traveller constraints. That leads to schedules that look polished but ignore transfer friction, energy levels, and booking realities."}},{"@type":"Question","name":"What should an AI travel planner validate before booking?","acceptedAnswer":{"@type":"Answer","text":"At minimum: route order, airport or rail transfer windows, hotel location relative to your day plan, day density, and whether a long-haul or red-eye requires recovery time."}},{"@type":"Question","name":"What details should I give AI before asking for an itinerary?","acceptedAnswer":{"@type":"Answer","text":"Include dates, arrival and departure cities, number of stops, transfer tolerance, budget shape, accommodation preferences, and any pace constraints such as travelling with children or needing recovery time after long-haul flights."}},{"@type":"Question","name":"What details should I add when points, borders, or family logistics matter?","acceptedAnswer":{"@type":"Answer","text":"Tell the planner about loyalty programs, points-versus-cash preferences, passport or visa constraints, baggage tolerance, latest acceptable arrival times, and family timing limits. Those details change route order, hotel choice, and whether a transfer is actually safe."}},{"@type":"Question","name":"Can AI plan a multi-city trip well?","acceptedAnswer":{"@type":"Answer","text":"Yes, but only when the planner checks sequencing and buffers. Multi-city trips break when each leg is treated as an isolated suggestion rather than part of one connected route."}}]}
     </script>
 </head>
 <body class="blog-page">
@@ -183,7 +183,40 @@
 <p>Plan a trip for <strong>[who is travelling]</strong> from <strong>[start date]</strong> to <strong>[end date]</strong>.<br>Start in <strong>[arrival city]</strong> and end in <strong>[departure city]</strong>.<br>I want <strong>[number of cities / regions]</strong> with <strong>[low / medium / high]</strong> pacing.<br>Prioritise <strong>[must-do experiences]</strong> and avoid <strong>[deal-breakers]</strong>.<br>Keep transfer days under <strong>[time limit]</strong> when possible.<br>Budget shape: <strong>[save on hotels / spend on location / balanced]</strong>.<br>Accommodation preference: <strong>[hotel / apartment / mixed]</strong>.<br>Important constraints: <strong>[children, accessibility needs, late arrival, early flight, remote work hours, loyalty status, etc.]</strong>.<br>Return 3 route options, key trade-offs, and any travel-day risks before giving a day-by-day itinerary.</p>
 </blockquote>
 <p>This is much closer to how a real traveller plans than asking for “the best itinerary.” It also makes the outputs easier to compare across Google, ChatGPT, and dedicated trip-planning tools.</p>
-<h2>6) Keep the answers structured enough to reuse</h2>
+<h2>6) Add edge-case constraints before they become expensive</h2>
+<p>Many weak AI itineraries do not fail because the city list is wrong. They fail because the prompt left out a detail that becomes expensive later: a border queue, a points booking rule, a baggage limit, or a family timing constraint.</p>
+<p>Before you accept a route, add the constraints that most often change the answer:</p>
+<table>
+<thead>
+<tr>
+<th>Situation</th>
+<th>Add this to your brief</th>
+<th>Why it changes the plan</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>Points or elite-status trip</td>
+<td>Airlines or hotel brands you want to prioritise, points-versus-cash preference, free-bag perks, willingness to reposition</td>
+<td>Can change airport choice, overnight logic, and whether a “cheap” leg is still worth taking</td>
+</tr>
+<tr>
+<td>Cross-border or major-event trip</td>
+<td>Passport or visa constraints, border sensitivity, event dates, and latest acceptable arrival time</td>
+<td>Helps the planner avoid brittle same-day transfers and underestimating queue risk</td>
+</tr>
+<tr>
+<td>Family or mixed-energy group</td>
+<td>Nap windows, walking limits, stroller needs, split-day tolerance, and recovery blocks</td>
+<td>Changes neighbourhood choice, activity density, and how aggressive each move can be</td>
+</tr>
+<tr>
+<td>Remote-work or fixed-schedule trip</td>
+<td>Call hours, quiet-work requirements, check-in timing, and must-be-online windows</td>
+<td>Prevents attractive routes that break your real calendar</td>
+</tr>
+</tbody></table>
+<p>If your trip mixes rail and flights, pressure-test the answer with our <a href="../blog/rail-vs-flight-cost-analysis.html">rail vs flight cost analysis</a>. If you are balancing adults, kids, or different travel styles, cross-check the route against <a href="../blog/bali-for-families.html">family pacing</a> and <a href="../blog/future-of-group-planning.html">group preference trade-offs</a> before booking.</p>
+<h2>7) Keep the answers structured enough to reuse</h2>
 <p>Google’s AI-search guidance increasingly rewards <strong>clear, useful, non-commodity content</strong>. The same principle applies when you use AI to plan a trip for yourself: structure beats noise.</p>
 <p>Ask for outputs like:</p>
 <ul>
@@ -195,12 +228,12 @@
 </ul>
 <p>That is far more reusable than a wall of generic prose.</p>
 <p>If you are comparing options, save the output in sections such as <strong>route</strong>, <strong>timing risks</strong>, <strong>hotel logic</strong>, and <strong>trade-offs</strong>. This makes it easier to judge whether the planner is helping you think or just generating volume.</p>
-<h2>7) Use AI differently for single-city and multi-city trips</h2>
+<h2>8) Use AI differently for single-city and multi-city trips</h2>
 <p>A single-city trip mostly needs help with <strong>neighbourhood fit, day clustering, and pacing</strong>.</p>
 <p>A multi-city trip needs help with <strong>sequence, transport legs, recovery windows, and booking order</strong>.</p>
 <p>That distinction matters because a planner that looks strong on destination ideas can still fail when you cross a border or add multiple hotel changes. If your trip has more moving parts, you need a planner that behaves more like a logistics layer than a chat surface.</p>
 <p>For a route with multiple stops, start with Alfred’s <a href="../ai-trip-planner/index.html">AI Trip Planner</a>, then compare the output against destination examples in the <a href="../itineraries/index.html">itinerary library</a>. If you are planning for children or a group, pressure-test the result against our guides to <a href="../blog/bali-for-families.html">family pacing</a> and <a href="../blog/future-of-group-planning.html">group preference trade-offs</a>. If the stay type is still unclear, use the <a href="../blog/ai-hotel-vs-airbnb-logic.html">hotel vs Airbnb logic guide</a> before you book.</p>
-<h2>8) Do not let AI hide trade-offs from you</h2>
+<h2>9) Do not let AI hide trade-offs from you</h2>
 <p>A generic itinerary usually pretends you can have everything at once:</p>
 <ul>
 <li>cheapest hotel,</li>

--- a/blog/how-to-plan-a-trip-with-ai-without-generic-itineraries.html
+++ b/blog/how-to-plan-a-trip-with-ai-without-generic-itineraries.html
@@ -1,0 +1,240 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>How to Plan a Trip With AI Without Ending Up With a Generic Itinerary | Alfred Travel Blog</title>
+    <meta name="description" content="A practical AI trip planning checklist for travellers who want more than a generic list of attractions. Learn how to set constraints, validate transfers, pressure-test pacing, and move toward a bookable trip.">
+    <meta name="keywords" content="how to plan a trip with AI, AI trip planning checklist, AI travel planner, multi-city trip planning, itinerary validation, Alfred Travel">
+    <link rel="canonical" href="https://www.alfredtravel.io/blog/how-to-plan-a-trip-with-ai-without-generic-itineraries.html">
+        <link rel="icon" type="image/png" sizes="16x16" href="../images/brand/favicon-16.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="../images/brand/favicon-32.png">
+    <link rel="icon" type="image/png" sizes="48x48" href="../images/brand/favicon-48.png">
+    <link rel="icon" type="image/png" sizes="512x512" href="../images/brand/favicon.png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../images/brand/apple-touch-icon.png">
+        <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="preconnect" href="https://api.fontshare.com" crossorigin>
+    <link rel="stylesheet" href="../css/tokens.css">
+    <link rel="stylesheet" href="../css/styles.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
+        <link rel="stylesheet" href="../css/typography.css">
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "SoftwareApplication",
+  "name": "Alfred Travel",
+  "operatingSystem": "iOS, Android, Web",
+  "applicationCategory": "TravelApplication",
+  "offers": {
+    "@type": "Offer",
+    "price": "0.00",
+    "priceCurrency": "USD"
+  },
+  "description": "Alfred is an AI travel planner for validated itineraries, multi-city travel, and booking-ready execution.",
+  "featureList": "AI Trip Planner, Validated Multi-City Planning, Booking-Ready Travel Flow, Google Maps Integration, Loyalty Rewards",
+  "softwareVersion": "1.0.18"
+}
+    </script>
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BlogPosting",
+  "headline": "How to Plan a Trip With AI Without Ending Up With a Generic Itinerary",
+  "description": "A practical AI trip planning checklist for travellers who want more than a generic list of attractions. Learn how to set constraints, validate transfers, pressure-test pacing, and move toward a bookable trip.",
+  "datePublished": "2026-06-15",
+  "author": {
+    "@type": "Person",
+    "name": "Alfred Team"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "Alfred Travel Tech Pty Ltd",
+    "url": "https://www.alfredtravel.io"
+  },
+  "url": "https://www.alfredtravel.io/blog/how-to-plan-a-trip-with-ai-without-generic-itineraries.html"
+}
+    </script>
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": "https://www.alfredtravel.io/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Blog",
+      "item": "https://www.alfredtravel.io/blog/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "name": "AI Travel",
+      "item": "https://www.alfredtravel.io/blog/?category=AI%20Travel"
+    },
+    {
+      "@type": "ListItem",
+      "position": 4,
+      "name": "How to Plan a Trip With AI Without Ending Up With a Generic Itinerary",
+      "item": "https://www.alfredtravel.io/blog/how-to-plan-a-trip-with-ai-without-generic-itineraries.html"
+    }
+  ]
+}
+    </script>
+    <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"How should I use AI to plan a trip?","acceptedAnswer":{"@type":"Answer","text":"Use AI to build and compare route options, then validate timing, hotel fit, and pacing before booking. The best results come from giving the model real constraints instead of broad prompts."}},{"@type":"Question","name":"Why do AI trip itineraries feel generic?","acceptedAnswer":{"@type":"Answer","text":"They often start from attraction lists instead of traveller constraints. That leads to schedules that look polished but ignore transfer friction, energy levels, and booking realities."}},{"@type":"Question","name":"What should an AI travel planner validate before booking?","acceptedAnswer":{"@type":"Answer","text":"At minimum: route order, airport or rail transfer windows, hotel location relative to your day plan, day density, and whether a long-haul or red-eye requires recovery time."}},{"@type":"Question","name":"Can AI plan a multi-city trip well?","acceptedAnswer":{"@type":"Answer","text":"Yes, but only when the planner checks sequencing and buffers. Multi-city trips break when each leg is treated as an isolated suggestion rather than part of one connected route."}}]}
+    </script>
+</head>
+<body class="blog-page">
+
+    <header>
+        <nav class="navbar" aria-label="Main navigation">
+            <div class="logo">
+                <a href="../index.html" class="brand-link" aria-label="Alfred Travel home">
+                    <img src="../images/Color logo with background.png.png" alt="Alfred Travel" class="logo-image" />
+                </a>
+            </div>
+            <ul class="nav-links">
+                <li><a href="../products.html">Features</a></li>
+                <li><a href="../itineraries/index.html">Itineraries</a></li>
+                <li><a href="index.html" class="nav-blog-active">Blog</a></li>
+                <li><a href="../compare/index.html">Compare</a></li>
+                <li><a href="../faq.html">FAQ</a></li>
+            </ul>
+            <a href="../index.html#app-downloads" class="download-cta" aria-label="Download Alfred on iOS or Android">Download App</a>
+            <div class="hamburger"><span></span><span></span><span></span></div>
+        </nav>
+    </header>
+    <main class="blog-main">
+        <article class="blog-article">
+            <nav class="blog-breadcrumb" aria-label="Breadcrumb">Home &rarr; <a href="index.html">Blog</a> &rarr; AI Travel &rarr; <span>How to Plan a Trip With AI Without Ending Up With a Generic Itinerary</span></nav>
+            <header class="blog-article-header">
+                <p class="blog-meta"><time datetime="2026-06-15">2026-06-15</time> &middot; Alfred Team &middot; AI Travel</p>
+                <h1 class="blog-article-title">How to Plan a Trip With AI Without Ending Up With a Generic Itinerary</h1>
+            </header>
+            <aside class="blog-takeaways-callout" aria-label="Key takeaways">
+    <h3 class="blog-takeaways-title">Key takeaways</h3>
+    <ul class="blog-takeaways-list"><li>Good AI trip planning starts with constraints such as travel days, transfer tolerance, budget shape, and who is travelling—not with a generic list of attractions.</li>
+<li>A useful AI travel plan needs validation for route order, hotel location, transfer buffers, and recovery time before you book anything.</li>
+<li>Clear, structured answers beat vague inspiration when travellers compare planners in Google, ChatGPT, and other answer engines.</li></ul>
+  </aside>
+            <div class="blog-article-body"><p>If you use AI for travel planning, the hard part is <strong>not</strong> getting ideas. The hard part is turning those ideas into a route that still works once <strong>transfers, hotel location, pacing, and booking decisions</strong> enter the picture.</p>
+<p>That is where many AI itineraries become generic. They give you a tidy list of sights, restaurants, and day trips, but they do not force the plan to survive real-world constraints.</p>
+<p>This guide is a simple way to use AI better: start with the trip spine, pressure-test the weak points, and only then move toward booking.</p>
+<h2>1) Start with constraints, not attractions</h2>
+<p>A better AI trip prompt begins with the limits of the trip:</p>
+<ul>
+<li><strong>How many days do you have?</strong></li>
+<li><strong>Are you moving between cities or staying put?</strong></li>
+<li><strong>How much transfer friction can your group tolerate?</strong></li>
+<li><strong>Are you travelling solo, as a couple, with friends, or with children?</strong></li>
+<li><strong>Do you want intense sightseeing, slower pacing, or a mixed trip?</strong></li>
+</ul>
+<p>If you start with “give me the best itinerary for Italy,” the model usually returns a familiar loop. If you start with “7 days, Rome + Florence, one train move, no 6 a.m. starts, and one recovery block after arrival,” you get a much more useful answer.</p>
+<p>That is the difference between <strong>AI inspiration</strong> and <strong>AI trip planning</strong>.</p>
+<h2>2) Ask AI for route options before day-by-day detail</h2>
+<p>Before you ask for museums, cafés, or hidden gems, ask for <strong>2 to 3 route structures</strong>.</p>
+<p>For example:</p>
+<ul>
+<li>Option A: fewer cities, deeper stay</li>
+<li>Option B: faster loop with one travel-heavy day</li>
+<li>Option C: same destinations but lower hotel-switching pressure</li>
+</ul>
+<p>This matters because many bad itineraries fail at the <strong>route level</strong>, not the attraction level. If the city order is wrong, every later decision gets harder.</p>
+<p>Travellers comparing tools in Google or ChatGPT often need this exact help first: <strong>what is the right shape of the trip?</strong> That is also why Alfred focuses on <a href="../blog/itinerary-validation-engine.html">validated itinerary structure</a> instead of only generating destination lists.</p>
+<h2>3) Validate the four failure points before you trust the plan</h2>
+<p>Most AI-generated trips break in one of these places:</p>
+<h3>Route order</h3>
+<p>Is the city sequence logical, or are you zig-zagging for no reason?</p>
+<h3>Transfer windows</h3>
+<p>Did the plan leave realistic time for airport arrival, station changes, baggage, customs, or traffic?</p>
+<h3>Hotel fit</h3>
+<p>Is the hotel area close to what you will actually do, or did the plan optimise for price while making every day harder?</p>
+<h3>Pacing</h3>
+<p>Does the itinerary assume full energy every day, even after long flights, late arrivals, or children skipping naps?</p>
+<p>If a tool does not help you think through those four questions, you still have a <strong>generic itinerary</strong>—just in a nicer format.</p>
+<h2>4) Use a simple AI trip planning checklist</h2>
+<p>Before you book, ask whether the plan can pass this checklist:</p>
+<ol>
+<li><p><strong>Each travel day has buffer time.</strong><br>No unrealistic airport-to-hotel-to-tour chain the moment you land.</p>
+</li>
+<li><p><strong>Each hotel location reduces friction.</strong><br>Closer to the station, airport link, or core activity zone when that matters.</p>
+</li>
+<li><p><strong>Each city earns its place.</strong><br>If one stop adds stress but not meaning, remove it.</p>
+</li>
+<li><p><strong>Each high-intensity day is balanced.</strong><br>Follow a heavy museum or transit day with something lighter.</p>
+</li>
+<li><p><strong>Each booking decision supports the route.</strong><br>Cheap does not help if it creates expensive time loss later.</p>
+</li>
+<li><p><strong>Each “must-do” item is anchored to a realistic day.</strong><br>Do not let the AI bury your priorities inside a crowded schedule.</p>
+</li>
+<li><p><strong>Each leg still works if something slips.</strong><br>Good trips survive delay; brittle trips collapse.</p>
+</li>
+</ol>
+<h2>5) Keep the answers structured enough to reuse</h2>
+<p>Google’s AI-search guidance increasingly rewards <strong>clear, useful, non-commodity content</strong>. The same principle applies when you use AI to plan a trip for yourself: structure beats noise.</p>
+<p>Ask for outputs like:</p>
+<ul>
+<li>a route summary,</li>
+<li>one paragraph on why the route order works,</li>
+<li>travel-day warnings,</li>
+<li>hotel-zone advice,</li>
+<li>and a shortlist of optional swaps.</li>
+</ul>
+<p>That is far more reusable than a wall of generic prose.</p>
+<p>If you are comparing options, save the output in sections such as <strong>route</strong>, <strong>timing risks</strong>, <strong>hotel logic</strong>, and <strong>trade-offs</strong>. This makes it easier to judge whether the planner is helping you think or just generating volume.</p>
+<h2>6) Use AI differently for single-city and multi-city trips</h2>
+<p>A single-city trip mostly needs help with <strong>neighbourhood fit, day clustering, and pacing</strong>.</p>
+<p>A multi-city trip needs help with <strong>sequence, transport legs, recovery windows, and booking order</strong>.</p>
+<p>That distinction matters because a planner that looks strong on destination ideas can still fail when you cross a border or add multiple hotel changes. If your trip has more moving parts, you need a planner that behaves more like a logistics layer than a chat surface.</p>
+<p>For a route with multiple stops, start with Alfred’s <a href="../ai-trip-planner/index.html">AI Trip Planner</a>, then compare the output against destination examples in the <a href="../itineraries/index.html">itinerary library</a>.</p>
+<h2>7) Do not let AI hide trade-offs from you</h2>
+<p>A generic itinerary usually pretends you can have everything at once:</p>
+<ul>
+<li>cheapest hotel,</li>
+<li>shortest travel day,</li>
+<li>best location,</li>
+<li>and maximum sightseeing.</li>
+</ul>
+<p>Real planning is trade-off management.</p>
+<p>The better question is not “what is the perfect plan?” It is “<strong>which compromise hurts the least for this traveller?</strong>”</p>
+<p>For families, that may mean fewer hotel changes. For couples, it may mean paying more for a walkable neighbourhood. For friend groups, it may mean keeping one flexible day so the trip does not become a rigid spreadsheet.</p>
+<h2>A better workflow for AI trip planning</h2>
+<p>If you want a simple repeatable process, use this order:</p>
+<ol>
+<li>Define constraints.</li>
+<li>Compare route shapes.</li>
+<li>Draft day structure.</li>
+<li>Validate transfer and hotel logic.</li>
+<li>Remove one unnecessary stress point.</li>
+<li>Book only when the route feels stable.</li>
+</ol>
+<p>That workflow is slower than asking for “the best itinerary.” It is also much closer to how good trips are actually built.</p>
+<h2>Final thought</h2>
+<p>The future of travel planning is not more AI text. It is <strong>better trip decisions</strong>.</p>
+<p>The AI tools that win in Google, ChatGPT, and real traveller workflows will be the ones that make plans <strong>clearer, more practical, and easier to execute</strong>. If the itinerary still falls apart when you inspect timing and logistics, it was never a strong plan—just a polished draft.</p>
+<p>If you want to move from broad inspiration to a route you can actually use, start with Alfred’s <a href="../ai-trip-planner/index.html">AI Trip Planner</a>, then cross-check your trip shape with the <a href="../faq.html">FAQ</a>, <a href="../products.html">feature overview</a>, and <a href="../blog/itinerary-validation-engine.html">itinerary validation guide</a>.</p>
+</div>
+        </article>
+    </main>
+
+    <footer>
+        <div class="footer-content">
+            <div class="footer-column"><h3>Company</h3><ul class="footer-links"><li><a href="../about.html">About Us</a></li><li><a href="../about.html#mission">Our Mission</a></li><li><a href="../about.html#team">Our Team</a></li><li><a href="../index.html#features">Features</a></li></ul></div>
+            <div class="footer-column"><h3>Features</h3><ul class="footer-links"><li><a href="../products.html">Our Features</a></li><li><a href="../itineraries/index.html">Itineraries</a></li><li><a href="../compare/index.html">Compare</a></li><li><a href="index.html">Blog</a></li><li><a href="../faq.html">FAQ</a></li></ul></div>
+            <div class="footer-column"><h3>Solutions</h3><ul class="footer-links"><li><a href="../ai-trip-planner/index.html">AI Trip Planner</a></li><li><a href="../ai-travel-planner/index.html">AI Travel Planner</a></li><li><a href="../ai-holiday-planner/index.html">AI Holiday Planner</a></li></ul></div>
+            <div class="footer-column"><h3>Support</h3><ul class="footer-links"><li><a href="../delete-account.html">Support Center</a></li><li><a href="../index.html#contact">Contact Us</a></li><li><a href="../faq.html">Help & FAQ</a></li></ul></div>
+            <div class="footer-column"><h3>Legal</h3><ul class="footer-links"><li><a href="../terms.html">Terms & Conditions</a></li><li><a href="../terms.html#privacy">Privacy Policy</a></li><li><a href="../prize-tc.html">Prize Terms</a></li></ul></div>
+        </div>
+        <div class="footer-bottom"><p>&copy; 2026 Alfred Travel Tech Pty Ltd. All rights reserved.</p></div>
+    </footer>
+    <div id="cookies-banner" class="cookies-banner"><div class="cookies-content"><div class="cookies-text"><h3>🍪 We use cookies</h3><p>We use cookies and similar technologies. <a href="../terms.html#privacy" class="cookies-link">Privacy Policy</a> · <a href="#" class="cookies-link" id="cookie-settings">Cookie Settings</a>.</p></div><div class="cookies-buttons"><button id="accept-all-cookies" class="btn btn-primary">Accept All</button><button id="reject-cookies" class="btn btn-secondary">Reject All</button></div></div></div>
+    <script src="../js/main.js"></script>
+</body>
+</html>

--- a/blog/how-to-plan-a-trip-with-ai-without-generic-itineraries.html
+++ b/blog/how-to-plan-a-trip-with-ai-without-generic-itineraries.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>How to Plan a Trip With AI Without Ending Up With a Generic Itinerary | Alfred Travel Blog</title>
-    <meta name="description" content="A practical AI trip planning checklist for travellers who want more than a generic list of attractions. Learn how to set constraints, validate transfers, pressure-test pacing, and move toward a bookable trip.">
-    <meta name="keywords" content="how to plan a trip with AI, AI trip planning checklist, AI travel planner, multi-city trip planning, itinerary validation, Alfred Travel">
+    <meta name="description" content="A practical AI trip planning checklist and copy-and-paste trip brief for travellers who want more than a generic list of attractions. Learn how to set constraints, validate transfers, pressure-test pacing, and move toward a bookable trip.">
+    <meta name="keywords" content="how to plan a trip with AI, AI trip planning checklist, AI travel planner, trip brief template, multi-city trip planning, itinerary validation, Alfred Travel">
     <link rel="canonical" href="https://www.alfredtravel.io/blog/how-to-plan-a-trip-with-ai-without-generic-itineraries.html">
         <link rel="icon" type="image/png" sizes="16x16" href="../images/brand/favicon-16.png">
     <link rel="icon" type="image/png" sizes="32x32" href="../images/brand/favicon-32.png">
@@ -41,7 +41,7 @@
   "@context": "https://schema.org",
   "@type": "BlogPosting",
   "headline": "How to Plan a Trip With AI Without Ending Up With a Generic Itinerary",
-  "description": "A practical AI trip planning checklist for travellers who want more than a generic list of attractions. Learn how to set constraints, validate transfers, pressure-test pacing, and move toward a bookable trip.",
+  "description": "A practical AI trip planning checklist and copy-and-paste trip brief for travellers who want more than a generic list of attractions. Learn how to set constraints, validate transfers, pressure-test pacing, and move toward a bookable trip.",
   "datePublished": "2026-06-15",
   "author": {
     "@type": "Person",
@@ -88,7 +88,7 @@
 }
     </script>
     <script type="application/ld+json">
-{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"How should I use AI to plan a trip?","acceptedAnswer":{"@type":"Answer","text":"Use AI to build and compare route options, then validate timing, hotel fit, and pacing before booking. The best results come from giving the model real constraints instead of broad prompts."}},{"@type":"Question","name":"Why do AI trip itineraries feel generic?","acceptedAnswer":{"@type":"Answer","text":"They often start from attraction lists instead of traveller constraints. That leads to schedules that look polished but ignore transfer friction, energy levels, and booking realities."}},{"@type":"Question","name":"What should an AI travel planner validate before booking?","acceptedAnswer":{"@type":"Answer","text":"At minimum: route order, airport or rail transfer windows, hotel location relative to your day plan, day density, and whether a long-haul or red-eye requires recovery time."}},{"@type":"Question","name":"Can AI plan a multi-city trip well?","acceptedAnswer":{"@type":"Answer","text":"Yes, but only when the planner checks sequencing and buffers. Multi-city trips break when each leg is treated as an isolated suggestion rather than part of one connected route."}}]}
+{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"How should I use AI to plan a trip?","acceptedAnswer":{"@type":"Answer","text":"Use AI to build and compare route options, then validate timing, hotel fit, and pacing before booking. The best results come from giving the model real constraints instead of broad prompts."}},{"@type":"Question","name":"Why do AI trip itineraries feel generic?","acceptedAnswer":{"@type":"Answer","text":"They often start from attraction lists instead of traveller constraints. That leads to schedules that look polished but ignore transfer friction, energy levels, and booking realities."}},{"@type":"Question","name":"What should an AI travel planner validate before booking?","acceptedAnswer":{"@type":"Answer","text":"At minimum: route order, airport or rail transfer windows, hotel location relative to your day plan, day density, and whether a long-haul or red-eye requires recovery time."}},{"@type":"Question","name":"What details should I give AI before asking for an itinerary?","acceptedAnswer":{"@type":"Answer","text":"Include dates, arrival and departure cities, number of stops, transfer tolerance, budget shape, accommodation preferences, and any pace constraints such as travelling with children or needing recovery time after long-haul flights."}},{"@type":"Question","name":"Can AI plan a multi-city trip well?","acceptedAnswer":{"@type":"Answer","text":"Yes, but only when the planner checks sequencing and buffers. Multi-city trips break when each leg is treated as an isolated suggestion rather than part of one connected route."}}]}
     </script>
 </head>
 <body class="blog-page">
@@ -122,7 +122,7 @@
     <h3 class="blog-takeaways-title">Key takeaways</h3>
     <ul class="blog-takeaways-list"><li>Good AI trip planning starts with constraints such as travel days, transfer tolerance, budget shape, and who is travelling—not with a generic list of attractions.</li>
 <li>A useful AI travel plan needs validation for route order, hotel location, transfer buffers, and recovery time before you book anything.</li>
-<li>Clear, structured answers beat vague inspiration when travellers compare planners in Google, ChatGPT, and other answer engines.</li></ul>
+<li>A reusable trip brief template helps travellers get structured answers they can compare, edit, and reuse across Google, ChatGPT, and planner tools.</li></ul>
   </aside>
             <div class="blog-article-body"><p>If you use AI for travel planning, the hard part is <strong>not</strong> getting ideas. The hard part is turning those ideas into a route that still works once <strong>transfers, hotel location, pacing, and booking decisions</strong> enter the picture.</p>
 <p>That is where many AI itineraries become generic. They give you a tidy list of sights, restaurants, and day trips, but they do not force the plan to survive real-world constraints.</p>
@@ -177,7 +177,13 @@
 <li><p><strong>Each leg still works if something slips.</strong><br>Good trips survive delay; brittle trips collapse.</p>
 </li>
 </ol>
-<h2>5) Keep the answers structured enough to reuse</h2>
+<h2>5) Copy and paste a trip brief before you ask for options</h2>
+<p>A vague prompt invites a vague answer. Before you ask for route ideas, write a short brief the model can actually use:</p>
+<blockquote>
+<p>Plan a trip for <strong>[who is travelling]</strong> from <strong>[start date]</strong> to <strong>[end date]</strong>.<br>Start in <strong>[arrival city]</strong> and end in <strong>[departure city]</strong>.<br>I want <strong>[number of cities / regions]</strong> with <strong>[low / medium / high]</strong> pacing.<br>Prioritise <strong>[must-do experiences]</strong> and avoid <strong>[deal-breakers]</strong>.<br>Keep transfer days under <strong>[time limit]</strong> when possible.<br>Budget shape: <strong>[save on hotels / spend on location / balanced]</strong>.<br>Accommodation preference: <strong>[hotel / apartment / mixed]</strong>.<br>Important constraints: <strong>[children, accessibility needs, late arrival, early flight, remote work hours, loyalty status, etc.]</strong>.<br>Return 3 route options, key trade-offs, and any travel-day risks before giving a day-by-day itinerary.</p>
+</blockquote>
+<p>This is much closer to how a real traveller plans than asking for “the best itinerary.” It also makes the outputs easier to compare across Google, ChatGPT, and dedicated trip-planning tools.</p>
+<h2>6) Keep the answers structured enough to reuse</h2>
 <p>Google’s AI-search guidance increasingly rewards <strong>clear, useful, non-commodity content</strong>. The same principle applies when you use AI to plan a trip for yourself: structure beats noise.</p>
 <p>Ask for outputs like:</p>
 <ul>
@@ -189,12 +195,12 @@
 </ul>
 <p>That is far more reusable than a wall of generic prose.</p>
 <p>If you are comparing options, save the output in sections such as <strong>route</strong>, <strong>timing risks</strong>, <strong>hotel logic</strong>, and <strong>trade-offs</strong>. This makes it easier to judge whether the planner is helping you think or just generating volume.</p>
-<h2>6) Use AI differently for single-city and multi-city trips</h2>
+<h2>7) Use AI differently for single-city and multi-city trips</h2>
 <p>A single-city trip mostly needs help with <strong>neighbourhood fit, day clustering, and pacing</strong>.</p>
 <p>A multi-city trip needs help with <strong>sequence, transport legs, recovery windows, and booking order</strong>.</p>
 <p>That distinction matters because a planner that looks strong on destination ideas can still fail when you cross a border or add multiple hotel changes. If your trip has more moving parts, you need a planner that behaves more like a logistics layer than a chat surface.</p>
-<p>For a route with multiple stops, start with Alfred’s <a href="../ai-trip-planner/index.html">AI Trip Planner</a>, then compare the output against destination examples in the <a href="../itineraries/index.html">itinerary library</a>.</p>
-<h2>7) Do not let AI hide trade-offs from you</h2>
+<p>For a route with multiple stops, start with Alfred’s <a href="../ai-trip-planner/index.html">AI Trip Planner</a>, then compare the output against destination examples in the <a href="../itineraries/index.html">itinerary library</a>. If you are planning for children or a group, pressure-test the result against our guides to <a href="../blog/bali-for-families.html">family pacing</a> and <a href="../blog/future-of-group-planning.html">group preference trade-offs</a>. If the stay type is still unclear, use the <a href="../blog/ai-hotel-vs-airbnb-logic.html">hotel vs Airbnb logic guide</a> before you book.</p>
+<h2>8) Do not let AI hide trade-offs from you</h2>
 <p>A generic itinerary usually pretends you can have everything at once:</p>
 <ul>
 <li>cheapest hotel,</li>

--- a/blog/how-to-plan-a-trip-with-ai-without-generic-itineraries.html
+++ b/blog/how-to-plan-a-trip-with-ai-without-generic-itineraries.html
@@ -88,7 +88,7 @@
 }
     </script>
     <script type="application/ld+json">
-{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"How should I use AI to plan a trip?","acceptedAnswer":{"@type":"Answer","text":"Use AI to build and compare route options, then validate timing, hotel fit, and pacing before booking. The best results come from giving the model real constraints instead of broad prompts."}},{"@type":"Question","name":"Why do AI trip itineraries feel generic?","acceptedAnswer":{"@type":"Answer","text":"They often start from attraction lists instead of traveller constraints. That leads to schedules that look polished but ignore transfer friction, energy levels, and booking realities."}},{"@type":"Question","name":"What should an AI travel planner validate before booking?","acceptedAnswer":{"@type":"Answer","text":"At minimum: route order, airport or rail transfer windows, hotel location relative to your day plan, day density, and whether a long-haul or red-eye requires recovery time."}},{"@type":"Question","name":"What details should I give AI before asking for an itinerary?","acceptedAnswer":{"@type":"Answer","text":"Include dates, arrival and departure cities, number of stops, transfer tolerance, budget shape, accommodation preferences, and any pace constraints such as travelling with children or needing recovery time after long-haul flights."}},{"@type":"Question","name":"What details should I add when points, borders, or family logistics matter?","acceptedAnswer":{"@type":"Answer","text":"Tell the planner about loyalty programs, points-versus-cash preferences, passport or visa constraints, baggage tolerance, latest acceptable arrival times, and family timing limits. Those details change route order, hotel choice, and whether a transfer is actually safe."}},{"@type":"Question","name":"Can AI plan a multi-city trip well?","acceptedAnswer":{"@type":"Answer","text":"Yes, but only when the planner checks sequencing and buffers. Multi-city trips break when each leg is treated as an isolated suggestion rather than part of one connected route."}}]}
+{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"How should I use AI to plan a trip?","acceptedAnswer":{"@type":"Answer","text":"Use AI to build and compare route options, then validate timing, hotel fit, and pacing before booking. The best results come from giving the model real constraints instead of broad prompts."}},{"@type":"Question","name":"Why do AI trip itineraries feel generic?","acceptedAnswer":{"@type":"Answer","text":"They often start from attraction lists instead of traveller constraints. That leads to schedules that look polished but ignore transfer friction, energy levels, and booking realities."}},{"@type":"Question","name":"What should an AI travel planner validate before booking?","acceptedAnswer":{"@type":"Answer","text":"At minimum: route order, airport or rail transfer windows, hotel location relative to your day plan, day density, and whether a long-haul or red-eye requires recovery time."}},{"@type":"Question","name":"What details should I give AI before asking for an itinerary?","acceptedAnswer":{"@type":"Answer","text":"Include dates, arrival and departure cities, number of stops, transfer tolerance, budget shape, accommodation preferences, and any pace constraints such as travelling with children or needing recovery time after long-haul flights."}},{"@type":"Question","name":"What details should I add when points, borders, or family logistics matter?","acceptedAnswer":{"@type":"Answer","text":"Tell the planner about loyalty programs, points-versus-cash preferences, passport or visa constraints, baggage tolerance, latest acceptable arrival times, and family timing limits. Those details change route order, hotel choice, and whether a transfer is actually safe."}},{"@type":"Question","name":"What follow-up prompt should I ask after the first AI itinerary?","acceptedAnswer":{"@type":"Answer","text":"Ask the model to rank the options by transfer risk, hotel switching, and recovery time, then rewrite the best option with warnings for borders, points, or family timing. The second pass is usually where a generic itinerary becomes usable."}},{"@type":"Question","name":"Can AI plan a multi-city trip well?","acceptedAnswer":{"@type":"Answer","text":"Yes, but only when the planner checks sequencing and buffers. Multi-city trips break when each leg is treated as an isolated suggestion rather than part of one connected route."}}]}
     </script>
 </head>
 <body class="blog-page">
@@ -216,7 +216,40 @@
 </tr>
 </tbody></table>
 <p>If your trip mixes rail and flights, pressure-test the answer with our <a href="../blog/rail-vs-flight-cost-analysis.html">rail vs flight cost analysis</a>. If you are balancing adults, kids, or different travel styles, cross-check the route against <a href="../blog/bali-for-families.html">family pacing</a> and <a href="../blog/future-of-group-planning.html">group preference trade-offs</a> before booking.</p>
-<h2>7) Keep the answers structured enough to reuse</h2>
+<h2>7) Use follow-up prompts to force trade-offs into the open</h2>
+<p>A first AI itinerary can sound confident while still hiding the real compromises. The fastest way to improve it is to ask a <strong>second-pass prompt</strong> that forces the model to explain what breaks first.</p>
+<p>Use follow-up prompts like these:</p>
+<table>
+<thead>
+<tr>
+<th>If your trip depends on...</th>
+<th>Ask AI this follow-up prompt</th>
+<th>A useful answer should include</th>
+</tr>
+</thead>
+<tbody><tr>
+<td>Comparing route shapes</td>
+<td>&quot;Rank these options by least transfer risk, least hotel switching, and best recovery time after arrival. Tell me which city should be cut first if I need a simpler trip.&quot;</td>
+<td>A ranked recommendation, the main trade-off in each option, and the first stress point to remove</td>
+</tr>
+<tr>
+<td>Points or loyalty rules</td>
+<td>&quot;Rewrite this route assuming I prefer alliance-friendly flights, want to compare points versus cash, and do not want a repositioning leg unless it saves a major amount.&quot;</td>
+<td>Cash-versus-points pinch points, reposition warnings, and where loyalty preferences change the route</td>
+</tr>
+<tr>
+<td>Borders or major events</td>
+<td>&quot;Stress-test this itinerary for border queues, event-day crowding, and the latest safe arrival time for each transfer day.&quot;</td>
+<td>Brittle same-day legs, buffer recommendations, and any stop that needs an earlier arrival</td>
+</tr>
+<tr>
+<td>Family or mixed-energy pacing</td>
+<td>&quot;Rewrite this plan with one recovery block after heavy travel days, shorter walking windows, and one low-friction backup option per day.&quot;</td>
+<td>A lighter day structure, neighbourhood logic, and where over-scheduling is most likely</td>
+</tr>
+</tbody></table>
+<p>If the answer still refuses to show trade-offs, the planner is probably generating polished text instead of helping you make decisions. That is a good time to compare the route against Alfred’s <a href="../blog/ai-hotel-vs-airbnb-logic.html">hotel vs Airbnb logic guide</a> or the <a href="../ai-trip-planner/index.html">AI Trip Planner</a> before you book.</p>
+<h2>8) Keep the answers structured enough to reuse</h2>
 <p>Google’s AI-search guidance increasingly rewards <strong>clear, useful, non-commodity content</strong>. The same principle applies when you use AI to plan a trip for yourself: structure beats noise.</p>
 <p>Ask for outputs like:</p>
 <ul>
@@ -228,12 +261,12 @@
 </ul>
 <p>That is far more reusable than a wall of generic prose.</p>
 <p>If you are comparing options, save the output in sections such as <strong>route</strong>, <strong>timing risks</strong>, <strong>hotel logic</strong>, and <strong>trade-offs</strong>. This makes it easier to judge whether the planner is helping you think or just generating volume.</p>
-<h2>8) Use AI differently for single-city and multi-city trips</h2>
+<h2>9) Use AI differently for single-city and multi-city trips</h2>
 <p>A single-city trip mostly needs help with <strong>neighbourhood fit, day clustering, and pacing</strong>.</p>
 <p>A multi-city trip needs help with <strong>sequence, transport legs, recovery windows, and booking order</strong>.</p>
 <p>That distinction matters because a planner that looks strong on destination ideas can still fail when you cross a border or add multiple hotel changes. If your trip has more moving parts, you need a planner that behaves more like a logistics layer than a chat surface.</p>
 <p>For a route with multiple stops, start with Alfred’s <a href="../ai-trip-planner/index.html">AI Trip Planner</a>, then compare the output against destination examples in the <a href="../itineraries/index.html">itinerary library</a>. If you are planning for children or a group, pressure-test the result against our guides to <a href="../blog/bali-for-families.html">family pacing</a> and <a href="../blog/future-of-group-planning.html">group preference trade-offs</a>. If the stay type is still unclear, use the <a href="../blog/ai-hotel-vs-airbnb-logic.html">hotel vs Airbnb logic guide</a> before you book.</p>
-<h2>9) Do not let AI hide trade-offs from you</h2>
+<h2>10) Do not let AI hide trade-offs from you</h2>
 <p>A generic itinerary usually pretends you can have everything at once:</p>
 <ul>
 <li>cheapest hotel,</li>

--- a/blog/index.html
+++ b/blog/index.html
@@ -82,7 +82,7 @@
         <a href="how-to-plan-a-trip-with-ai-without-generic-itineraries.html" class="blog-index-link">
           <h2 class="blog-index-title">How to Plan a Trip With AI Without Ending Up With a Generic Itinerary</h2>
           <p class="blog-index-meta">2026-06-15 &middot; Alfred Team &middot; AI Travel</p>
-          <p class="blog-index-excerpt">A practical AI trip planning checklist for travellers who want more than a generic list of attractions. Learn how to set constraints, validate transfers, pressu</p>
+          <p class="blog-index-excerpt">A practical AI trip planning checklist and copy-and-paste trip brief for travellers who want more than a generic list of attractions. Learn how to set constrain</p>
         </a>
       </li>
 <li class="blog-index-item">

--- a/blog/index.html
+++ b/blog/index.html
@@ -79,6 +79,13 @@
                     <p class="tai-agn-desc">Skift reactions, destination guides, and planning notes—newest first.</p>
                     <ul class="blog-index-list" role="list">
 <li class="blog-index-item">
+        <a href="ai-hotel-vs-airbnb-logic.html" class="blog-index-link">
+          <h2 class="blog-index-title">AI Hotel vs Airbnb Logic: When to Book Which (And Why It's a Logistical Question)</h2>
+          <p class="blog-index-meta">2026-06-20 &middot; Alfred Team &middot; AI Travel</p>
+          <p class="blog-index-excerpt">A practical hotel-vs-Airbnb decision guide for AI trip planning. Learn when hotels win, when Airbnb works better, what to validate before booking, and how stay </p>
+        </a>
+      </li>
+<li class="blog-index-item">
         <a href="how-to-plan-a-trip-with-ai-without-generic-itineraries.html" class="blog-index-link">
           <h2 class="blog-index-title">How to Plan a Trip With AI Without Ending Up With a Generic Itinerary</h2>
           <p class="blog-index-meta">2026-06-15 &middot; Alfred Team &middot; AI Travel</p>
@@ -300,13 +307,6 @@
           <h2 class="blog-index-title">The Death of Human Agents (And Why Travel 3.0 Is an Engine, Not a Person)</h2>
           <p class="blog-index-meta">2025-12-17 &middot; Alfred Team &middot; AIO Insights</p>
           <p class="blog-index-excerpt">Travel 1.0 was agents; 2.0 was DIY overload. Travel 3.0 is Alfred—logistical validation at scale, not a callback.</p>
-        </a>
-      </li>
-<li class="blog-index-item">
-        <a href="ai-hotel-vs-airbnb-logic.html" class="blog-index-link">
-          <h2 class="blog-index-title">AI Hotel vs Airbnb Logic: When to Book Which (And Why It's a Logistical Question)</h2>
-          <p class="blog-index-meta">2025-12-16 &middot; Alfred Team &middot; AIO Insights</p>
-          <p class="blog-index-excerpt">Hotel vs Airbnb isn't vibes—it's location, check-in windows, and trip structure. Alfred's logic, not guesswork.</p>
         </a>
       </li>
 <li class="blog-index-item">

--- a/blog/index.html
+++ b/blog/index.html
@@ -79,6 +79,13 @@
                     <p class="tai-agn-desc">Skift reactions, destination guides, and planning notes—newest first.</p>
                     <ul class="blog-index-list" role="list">
 <li class="blog-index-item">
+        <a href="how-to-plan-a-trip-with-ai-without-generic-itineraries.html" class="blog-index-link">
+          <h2 class="blog-index-title">How to Plan a Trip With AI Without Ending Up With a Generic Itinerary</h2>
+          <p class="blog-index-meta">2026-06-15 &middot; Alfred Team &middot; AI Travel</p>
+          <p class="blog-index-excerpt">A practical AI trip planning checklist for travellers who want more than a generic list of attractions. Learn how to set constraints, validate transfers, pressu</p>
+        </a>
+      </li>
+<li class="blog-index-item">
         <a href="india-travel-ai-delhi-execution.html" class="blog-index-link">
           <h2 class="blog-index-title">India’s Travel AI Push Makes Structured Delhi Trip Planning More Valuable</h2>
           <p class="blog-index-meta">2026-06-11 &middot; Alfred Team &middot; Travel notes</p>

--- a/content/blog/ai-hotel-vs-airbnb-logic.md
+++ b/content/blog/ai-hotel-vs-airbnb-logic.md
@@ -1,33 +1,166 @@
 ---
 title: "AI Hotel vs Airbnb Logic: When to Book Which (And Why It's a Logistical Question)"
-date: "2025-12-16"
-excerpt: "Hotel vs Airbnb isn't vibes—it's location, check-in windows, and trip structure. Alfred's logic, not guesswork."
+description: "A practical hotel-vs-Airbnb decision guide for AI trip planning. Learn when hotels win, when Airbnb works better, what to validate before booking, and how stay choice changes with late arrivals, families, remote work, and multi-city trips."
+keywords: "hotel vs Airbnb, AI travel planning, accommodation decision guide, multi-city trip planning, family travel accommodation, remote work travel, Alfred Travel"
+date: "2026-06-20"
+excerpt: "Hotel vs Airbnb is not a vibes question. It is a trip-structure question shaped by check-in windows, location, transfer friction, family pacing, and how often you are moving."
 author: "Alfred Team"
-category: "AIO Insights"
-tags: ["AI Travel", "Logistics", "Multi-City"]
+category: "AI Travel"
+tags: ["AI Travel", "Accommodation", "Travel Checklist", "Multi-City"]
 takeaways:
-  - "Alfred treats accommodation as part of itinerary logic: location, check-in, and transit to next leg."
-  - "Integrated global booking (Trip.com, Expedia, etc.) keeps plan and book in one flow—no affiliate hop."
-  - "Country-locked or static planners can't optimize stay type by trip structure; Alfred can."
+  - "Stay choice should follow trip structure: arrival time, departure pressure, neighbourhood fit, transfer friction, and how many times you are moving."
+  - "Hotels usually win for short stays, late arrivals, early departures, and multi-city trips where reliability matters more than extra space."
+  - "Airbnb can win for longer stays, family routines, laundry, kitchen access, and split schedules—but only when the location and host rules still fit the route."
+  - "A useful AI travel planner should validate accommodation against the itinerary, not treat booking as a separate afterthought."
+faqs:
+  - question: "Is a hotel or Airbnb better for a short city break?"
+    answer: "Hotels usually win on short trips because check-in is simpler, arrival friction is lower, and the cost of a poor location or awkward host timing is harder to recover from when you only have a few days."
+  - question: "When does Airbnb make more sense than a hotel?"
+    answer: "Airbnb usually makes more sense when you need more space, laundry, kitchen access, or a quieter residential setup for a longer stay, especially for families or slower-paced trips."
+  - question: "Should I use the same stay type for every city in a multi-city trip?"
+    answer: "No. The right stay type can change by stop. A hotel may be better near an airport or station on a transit-heavy leg, while an apartment may work better in a longer destination stay."
+  - question: "What should AI validate before recommending a hotel or Airbnb?"
+    answer: "It should validate arrival time, check-in flexibility, luggage friction, transport links, neighbourhood fit, cancellation terms, and whether the stay supports the next leg of the itinerary."
+  - question: "How does family travel change the hotel-vs-Airbnb decision?"
+    answer: "Family travel raises the value of extra space, kitchens, laundry, and predictable quiet time, but it also makes location and access more important. A spacious apartment that adds long daily transfers can still be the wrong choice."
 ---
 
-Hotel vs Airbnb isn’t a personality test—it’s **logistics**: check-in times, location relative to your first/last activity, and whether you’re doing one city or five. **Alfred Travel** models it that way: your itinerary’s **transit validation** and **activity gating** inform where you stay and when, so the “AI hotel vs Airbnb” question gets an answer that fits the trip.
+Hotel vs Airbnb is not a personality test. It is a **trip-structure decision**.
 
-## Comparison Table: How We Reason About Stay
+The right stay depends on what the rest of the itinerary is trying to do: when you land, how often you move, whether you need laundry or kitchen access, how fragile the pacing is, and how much friction your group can tolerate.
 
-| Factor | Vibes / generic advice | Alfred Travel |
-|--------|-------------------------|----------------|
-| Check-in vs. arrival | Ignored | Validated: late flight → hotel with 24h reception or adjusted plan |
-| Location | “Central is best” | Tied to your validated transit (e.g. station, first day’s zone) |
-| Multi-city | Same rule everywhere | Hotel vs Airbnb can vary by city in one itinerary |
-| Booking | Links out to OTAs | Integrated global booking; plan and book in one place |
+That is why broad advice like “Airbnb is more authentic” or “hotels are easier” is only partly useful. A stay that looks perfect in isolation can still make the whole trip worse if it adds a bad transfer, a risky late check-in, or a neighbourhood that fights the rest of your plan.
 
-We **validate** that your Day 1 landing and Day 5 early flight are compatible with your stay type and location—so the recommendation is **logistical**, not generic.
+If you are using AI to plan a trip, accommodation should be validated the same way you validate route order, airport buffers, and travel-day density.
 
-## Why Alfred Wins on This
+## Start with the shape of the trip, not the property type
 
-- **One itinerary:** Accommodation is part of the same plan as trains, activities, and transfers.
-- **Integrated booking:** No “here’s a link, good luck”—we keep you in the Alfred flow.
-- **Multi-city:** Different cities can get different stay logic (e.g. hotel in Paris, Airbnb in Lyon) in one validated plan.
+Before you compare listings, define the conditions that change the answer:
 
-Stop planning, start traveling. Open this itinerary in the [Alfred App](https://www.alfredtravel.io).
+- **How many nights are you staying?**
+- **Are you moving city-to-city or staying put?**
+- **Do you land late or leave early?**
+- **Do you need laundry, a kitchen, or separate sleeping space?**
+- **Will your day plan depend on a station, beach, meeting point, or walkable centre?**
+- **How expensive is a bad check-in experience for this trip?**
+
+A two-night stop after a late flight is a very different accommodation problem from a seven-night family base or a month-long remote-work stay.
+
+## The fastest hotel-vs-Airbnb decision table
+
+| Trip condition | Hotel usually wins when... | Airbnb usually wins when... |
+| --- | --- | --- |
+| **Arrival and check-in** | You land late, need 24-hour reception, or cannot afford host-message uncertainty | You can arrive in daylight and the host process is predictable |
+| **Length of stay** | It is a short break and convenience matters more than extra space | You are staying long enough to use the kitchen, laundry, or living area |
+| **Trip style** | You are moving every few nights and need low-friction transitions | You are anchoring in one neighbourhood and want a residential base |
+| **Group setup** | Everyone can share one or two standard rooms easily | You need separate bedrooms, naps, or split schedules |
+| **Location logic** | You need to be close to a station, airport bus, or early activity zone | A residential location improves the stay without breaking transport |
+| **Risk tolerance** | You want clearer cancellation, storage, support, and backup options | You are comfortable trading some certainty for space or local fit |
+
+That is the core rule: **the more brittle the trip, the more hotels tend to win. The longer and more settled the trip, the stronger the Airbnb case becomes.**
+
+## When hotels are the safer choice
+
+Hotels usually outperform Airbnb when the trip has very little slack.
+
+### 1) Late arrivals or early departures
+If you land after dinner, arrive from a delayed flight, or leave before sunrise, a staffed hotel is often the lower-risk choice. You are not relying on a host handoff, a self-check-in process that fails at the wrong moment, or messages arriving while you are still in transit.
+
+### 2) Short stays with tight sightseeing windows
+On a two- or three-night city break, convenience compounds fast. Easy luggage storage, predictable check-in, and a walkable or transit-linked location usually matter more than having a full kitchen.
+
+### 3) Transit-heavy multi-city trips
+When you are changing cities often, every stay transition has a cost. Hotels are often better for these stops because they reduce friction between station arrival, bag drop, sleep, and the next departure. If your trip needs a strong route spine first, start with Alfred’s [AI Trip Planner](../ai-trip-planner/index.html) or the [AI trip planning checklist](../blog/how-to-plan-a-trip-with-ai-without-generic-itineraries.html).
+
+### 4) Work trips or fixed schedules
+If you must be online at a specific time, cannot risk Wi-Fi ambiguity, or need a front desk to solve problems quickly, hotels usually provide a more predictable operating environment.
+
+### 5) Loyalty or bundled-value trips
+Breakfast, elite perks, points earnings, late checkout, and easy same-day support can make a hotel the better economic decision even when the nightly rate is higher on paper.
+
+## When Airbnb can be the better choice
+
+Airbnb usually starts winning when the stay itself is part of how the trip works.
+
+### 1) Longer stays where space matters
+If you are staying five nights or more, space, kitchens, and laundry can change the day-to-day economics of the trip. That is especially true when you want slower mornings, groceries, or a place to recover after long sightseeing days.
+
+### 2) Families and mixed-energy groups
+Families often need a different rhythm from couples or solo travellers. Separate sleeping space, snack access, and the ability to reset midday can outweigh hotel convenience. But the location still has to support the trip. A cheaper apartment thirty minutes from everything can erase the value of the extra space. If this is your main constraint, cross-check the plan against our [family pacing guide](../blog/bali-for-families.html).
+
+### 3) Residential neighbourhood stays
+Sometimes the goal is not to be in the busiest core but to settle into one district for a week, live closer to parks or local food, and slow the schedule down. Airbnb can work well here when the route is stable and daily transport still makes sense.
+
+### 4) Remote work or split-day travel
+A living area, table, kitchen, and quieter routine can matter more than daily housekeeping when you are working part of the day or balancing different traveler schedules.
+
+## The red flags that should flip your decision
+
+Even if a listing looks attractive, these warning signs usually mean you should reconsider the stay type or the neighbourhood:
+
+- **The airport or station transfer is awkward at the hour you arrive**
+- **Check-in depends on a narrow host window**
+- **The “cheap” option adds long daily backtracking**
+- **The first or last day becomes transit-heavy just because of the stay location**
+- **Laundry or kitchen benefits look good on paper but will not actually be used**
+- **You are carrying baggage, strollers, or work gear through stairs or long walks**
+- **You need predictable support if something slips**
+
+If one of those red flags appears, the stay is no longer just a price comparison. It is a route-risk problem.
+
+## Use different stay logic for different cities
+
+One of the most common planning mistakes is forcing the same accommodation rule across the whole trip.
+
+A better approach is to let each stop answer a different question:
+
+- **Arrival or departure city:** hotel near the transport spine
+- **Longer destination stay:** Airbnb if space and routine meaningfully improve the trip
+- **One-night connector stop:** hotel for low-friction sleep and bag handling
+- **Family beach or resort leg:** whichever option best supports rest, laundry, and meal flexibility without isolating you from the plan
+
+That is often the real answer to hotel vs Airbnb: **not one or the other, but which one fits each leg best**.
+
+## What to ask AI before you book
+
+A useful planner should not stop at “here are three properties.” It should explain the trade-offs.
+
+Use prompts like these:
+
+> Compare hotel vs Airbnb for this trip based on arrival time, check-in friction, walking distance to the main activity zone, luggage burden, and how stable the next transfer day is.
+
+> For each city, tell me whether a hotel or apartment reduces the most friction, and explain which one becomes risky if the arrival is delayed by two hours.
+
+> Rewrite this accommodation plan assuming I am traveling with children / remote work hours / one early flight / one late train arrival.
+
+The answer should discuss **timing, neighbourhood fit, and operational risk**—not just “hotels are convenient” or “Airbnbs are homier.”
+
+## A quick validation checklist before paying
+
+Before you book either stay type, pressure-test these points:
+
+1. **Arrival works in the real world.**  
+   If your flight slips, can you still check in safely?
+
+2. **Location supports the first and last day.**  
+   Not just the average day.
+
+3. **The stay reduces friction somewhere important.**  
+   Space, support, transport, laundry, or rest.
+
+4. **The cancellation terms match the risk.**  
+   Flexibility matters more on brittle routes.
+
+5. **The next transfer still works.**  
+   Especially on early trains, ferries, or flights.
+
+6. **The choice matches the group, not just the spreadsheet.**  
+   Families, couples, solo travellers, and work trips use space differently.
+
+## Final thought
+
+The right stay is the one that makes the whole itinerary easier to execute.
+
+For some trips that means a hotel with predictable support near the station. For others it means an apartment with laundry, kitchen access, and enough room for the trip to breathe. The winning choice is the one that fits the route, the timing, and the group—not the one that sounds best in generic travel advice.
+
+If you are still comparing route structure, start with the [AI trip planning checklist](../blog/how-to-plan-a-trip-with-ai-without-generic-itineraries.html). If family timing is the real blocker, use the [family pacing guide](../blog/bali-for-families.html). And if you want to validate all of it inside one planning flow, start with Alfred’s [AI Trip Planner](../ai-trip-planner/index.html).

--- a/content/blog/how-to-plan-a-trip-with-ai-without-generic-itineraries.md
+++ b/content/blog/how-to-plan-a-trip-with-ai-without-generic-itineraries.md
@@ -20,6 +20,8 @@ faqs:
     answer: "At minimum: route order, airport or rail transfer windows, hotel location relative to your day plan, day density, and whether a long-haul or red-eye requires recovery time."
   - question: "What details should I give AI before asking for an itinerary?"
     answer: "Include dates, arrival and departure cities, number of stops, transfer tolerance, budget shape, accommodation preferences, and any pace constraints such as travelling with children or needing recovery time after long-haul flights."
+  - question: "What details should I add when points, borders, or family logistics matter?"
+    answer: "Tell the planner about loyalty programs, points-versus-cash preferences, passport or visa constraints, baggage tolerance, latest acceptable arrival times, and family timing limits. Those details change route order, hotel choice, and whether a transfer is actually safe."
   - question: "Can AI plan a multi-city trip well?"
     answer: "Yes, but only when the planner checks sequencing and buffers. Multi-city trips break when each leg is treated as an isolated suggestion rather than part of one connected route."
 ---
@@ -117,7 +119,22 @@ A vague prompt invites a vague answer. Before you ask for route ideas, write a s
 
 This is much closer to how a real traveller plans than asking for “the best itinerary.” It also makes the outputs easier to compare across Google, ChatGPT, and dedicated trip-planning tools.
 
-## 6) Keep the answers structured enough to reuse
+## 6) Add edge-case constraints before they become expensive
+
+Many weak AI itineraries do not fail because the city list is wrong. They fail because the prompt left out a detail that becomes expensive later: a border queue, a points booking rule, a baggage limit, or a family timing constraint.
+
+Before you accept a route, add the constraints that most often change the answer:
+
+| Situation | Add this to your brief | Why it changes the plan |
+| --- | --- | --- |
+| Points or elite-status trip | Airlines or hotel brands you want to prioritise, points-versus-cash preference, free-bag perks, willingness to reposition | Can change airport choice, overnight logic, and whether a “cheap” leg is still worth taking |
+| Cross-border or major-event trip | Passport or visa constraints, border sensitivity, event dates, and latest acceptable arrival time | Helps the planner avoid brittle same-day transfers and underestimating queue risk |
+| Family or mixed-energy group | Nap windows, walking limits, stroller needs, split-day tolerance, and recovery blocks | Changes neighbourhood choice, activity density, and how aggressive each move can be |
+| Remote-work or fixed-schedule trip | Call hours, quiet-work requirements, check-in timing, and must-be-online windows | Prevents attractive routes that break your real calendar |
+
+If your trip mixes rail and flights, pressure-test the answer with our [rail vs flight cost analysis](../blog/rail-vs-flight-cost-analysis.html). If you are balancing adults, kids, or different travel styles, cross-check the route against [family pacing](../blog/bali-for-families.html) and [group preference trade-offs](../blog/future-of-group-planning.html) before booking.
+
+## 7) Keep the answers structured enough to reuse
 
 Google’s AI-search guidance increasingly rewards **clear, useful, non-commodity content**. The same principle applies when you use AI to plan a trip for yourself: structure beats noise.
 
@@ -133,7 +150,7 @@ That is far more reusable than a wall of generic prose.
 
 If you are comparing options, save the output in sections such as **route**, **timing risks**, **hotel logic**, and **trade-offs**. This makes it easier to judge whether the planner is helping you think or just generating volume.
 
-## 7) Use AI differently for single-city and multi-city trips
+## 8) Use AI differently for single-city and multi-city trips
 
 A single-city trip mostly needs help with **neighbourhood fit, day clustering, and pacing**.
 
@@ -143,7 +160,7 @@ That distinction matters because a planner that looks strong on destination idea
 
 For a route with multiple stops, start with Alfred’s [AI Trip Planner](../ai-trip-planner/index.html), then compare the output against destination examples in the [itinerary library](../itineraries/index.html). If you are planning for children or a group, pressure-test the result against our guides to [family pacing](../blog/bali-for-families.html) and [group preference trade-offs](../blog/future-of-group-planning.html). If the stay type is still unclear, use the [hotel vs Airbnb logic guide](../blog/ai-hotel-vs-airbnb-logic.html) before you book.
 
-## 8) Do not let AI hide trade-offs from you
+## 9) Do not let AI hide trade-offs from you
 
 A generic itinerary usually pretends you can have everything at once:
 

--- a/content/blog/how-to-plan-a-trip-with-ai-without-generic-itineraries.md
+++ b/content/blog/how-to-plan-a-trip-with-ai-without-generic-itineraries.md
@@ -1,0 +1,162 @@
+---
+title: "How to Plan a Trip With AI Without Ending Up With a Generic Itinerary"
+description: "A practical AI trip planning checklist for travellers who want more than a generic list of attractions. Learn how to set constraints, validate transfers, pressure-test pacing, and move toward a bookable trip."
+keywords: "how to plan a trip with AI, AI trip planning checklist, AI travel planner, multi-city trip planning, itinerary validation, Alfred Travel"
+date: "2026-06-15"
+excerpt: "If you use AI for travel planning, the hardest part is not getting ideas. It is turning those ideas into a route that still works once transfers, pacing, hotel location, and booking decisions enter the picture."
+author: "Alfred Team"
+category: "AI Travel"
+tags: ["AI Trip Planning", "Travel Checklist", "Itinerary Validation"]
+takeaways:
+  - "Good AI trip planning starts with constraints such as travel days, transfer tolerance, budget shape, and who is travelling—not with a generic list of attractions."
+  - "A useful AI travel plan needs validation for route order, hotel location, transfer buffers, and recovery time before you book anything."
+  - "Clear, structured answers beat vague inspiration when travellers compare planners in Google, ChatGPT, and other answer engines."
+faqs:
+  - question: "How should I use AI to plan a trip?"
+    answer: "Use AI to build and compare route options, then validate timing, hotel fit, and pacing before booking. The best results come from giving the model real constraints instead of broad prompts."
+  - question: "Why do AI trip itineraries feel generic?"
+    answer: "They often start from attraction lists instead of traveller constraints. That leads to schedules that look polished but ignore transfer friction, energy levels, and booking realities."
+  - question: "What should an AI travel planner validate before booking?"
+    answer: "At minimum: route order, airport or rail transfer windows, hotel location relative to your day plan, day density, and whether a long-haul or red-eye requires recovery time."
+  - question: "Can AI plan a multi-city trip well?"
+    answer: "Yes, but only when the planner checks sequencing and buffers. Multi-city trips break when each leg is treated as an isolated suggestion rather than part of one connected route."
+---
+
+If you use AI for travel planning, the hard part is **not** getting ideas. The hard part is turning those ideas into a route that still works once **transfers, hotel location, pacing, and booking decisions** enter the picture.
+
+That is where many AI itineraries become generic. They give you a tidy list of sights, restaurants, and day trips, but they do not force the plan to survive real-world constraints.
+
+This guide is a simple way to use AI better: start with the trip spine, pressure-test the weak points, and only then move toward booking.
+
+## 1) Start with constraints, not attractions
+
+A better AI trip prompt begins with the limits of the trip:
+
+- **How many days do you have?**
+- **Are you moving between cities or staying put?**
+- **How much transfer friction can your group tolerate?**
+- **Are you travelling solo, as a couple, with friends, or with children?**
+- **Do you want intense sightseeing, slower pacing, or a mixed trip?**
+
+If you start with “give me the best itinerary for Italy,” the model usually returns a familiar loop. If you start with “7 days, Rome + Florence, one train move, no 6 a.m. starts, and one recovery block after arrival,” you get a much more useful answer.
+
+That is the difference between **AI inspiration** and **AI trip planning**.
+
+## 2) Ask AI for route options before day-by-day detail
+
+Before you ask for museums, cafés, or hidden gems, ask for **2 to 3 route structures**.
+
+For example:
+
+- Option A: fewer cities, deeper stay
+- Option B: faster loop with one travel-heavy day
+- Option C: same destinations but lower hotel-switching pressure
+
+This matters because many bad itineraries fail at the **route level**, not the attraction level. If the city order is wrong, every later decision gets harder.
+
+Travellers comparing tools in Google or ChatGPT often need this exact help first: **what is the right shape of the trip?** That is also why Alfred focuses on [validated itinerary structure](../blog/itinerary-validation-engine.html) instead of only generating destination lists.
+
+## 3) Validate the four failure points before you trust the plan
+
+Most AI-generated trips break in one of these places:
+
+### Route order
+Is the city sequence logical, or are you zig-zagging for no reason?
+
+### Transfer windows
+Did the plan leave realistic time for airport arrival, station changes, baggage, customs, or traffic?
+
+### Hotel fit
+Is the hotel area close to what you will actually do, or did the plan optimise for price while making every day harder?
+
+### Pacing
+Does the itinerary assume full energy every day, even after long flights, late arrivals, or children skipping naps?
+
+If a tool does not help you think through those four questions, you still have a **generic itinerary**—just in a nicer format.
+
+## 4) Use a simple AI trip planning checklist
+
+Before you book, ask whether the plan can pass this checklist:
+
+1. **Each travel day has buffer time.**  
+   No unrealistic airport-to-hotel-to-tour chain the moment you land.
+
+2. **Each hotel location reduces friction.**  
+   Closer to the station, airport link, or core activity zone when that matters.
+
+3. **Each city earns its place.**  
+   If one stop adds stress but not meaning, remove it.
+
+4. **Each high-intensity day is balanced.**  
+   Follow a heavy museum or transit day with something lighter.
+
+5. **Each booking decision supports the route.**  
+   Cheap does not help if it creates expensive time loss later.
+
+6. **Each “must-do” item is anchored to a realistic day.**  
+   Do not let the AI bury your priorities inside a crowded schedule.
+
+7. **Each leg still works if something slips.**  
+   Good trips survive delay; brittle trips collapse.
+
+## 5) Keep the answers structured enough to reuse
+
+Google’s AI-search guidance increasingly rewards **clear, useful, non-commodity content**. The same principle applies when you use AI to plan a trip for yourself: structure beats noise.
+
+Ask for outputs like:
+
+- a route summary,
+- one paragraph on why the route order works,
+- travel-day warnings,
+- hotel-zone advice,
+- and a shortlist of optional swaps.
+
+That is far more reusable than a wall of generic prose.
+
+If you are comparing options, save the output in sections such as **route**, **timing risks**, **hotel logic**, and **trade-offs**. This makes it easier to judge whether the planner is helping you think or just generating volume.
+
+## 6) Use AI differently for single-city and multi-city trips
+
+A single-city trip mostly needs help with **neighbourhood fit, day clustering, and pacing**.
+
+A multi-city trip needs help with **sequence, transport legs, recovery windows, and booking order**.
+
+That distinction matters because a planner that looks strong on destination ideas can still fail when you cross a border or add multiple hotel changes. If your trip has more moving parts, you need a planner that behaves more like a logistics layer than a chat surface.
+
+For a route with multiple stops, start with Alfred’s [AI Trip Planner](../ai-trip-planner/index.html), then compare the output against destination examples in the [itinerary library](../itineraries/index.html).
+
+## 7) Do not let AI hide trade-offs from you
+
+A generic itinerary usually pretends you can have everything at once:
+
+- cheapest hotel,
+- shortest travel day,
+- best location,
+- and maximum sightseeing.
+
+Real planning is trade-off management.
+
+The better question is not “what is the perfect plan?” It is “**which compromise hurts the least for this traveller?**”
+
+For families, that may mean fewer hotel changes. For couples, it may mean paying more for a walkable neighbourhood. For friend groups, it may mean keeping one flexible day so the trip does not become a rigid spreadsheet.
+
+## A better workflow for AI trip planning
+
+If you want a simple repeatable process, use this order:
+
+1. Define constraints.
+2. Compare route shapes.
+3. Draft day structure.
+4. Validate transfer and hotel logic.
+5. Remove one unnecessary stress point.
+6. Book only when the route feels stable.
+
+That workflow is slower than asking for “the best itinerary.” It is also much closer to how good trips are actually built.
+
+## Final thought
+
+The future of travel planning is not more AI text. It is **better trip decisions**.
+
+The AI tools that win in Google, ChatGPT, and real traveller workflows will be the ones that make plans **clearer, more practical, and easier to execute**. If the itinerary still falls apart when you inspect timing and logistics, it was never a strong plan—just a polished draft.
+
+If you want to move from broad inspiration to a route you can actually use, start with Alfred’s [AI Trip Planner](../ai-trip-planner/index.html), then cross-check your trip shape with the [FAQ](../faq.html), [feature overview](../products.html), and [itinerary validation guide](../blog/itinerary-validation-engine.html).

--- a/content/blog/how-to-plan-a-trip-with-ai-without-generic-itineraries.md
+++ b/content/blog/how-to-plan-a-trip-with-ai-without-generic-itineraries.md
@@ -1,16 +1,16 @@
 ---
 title: "How to Plan a Trip With AI Without Ending Up With a Generic Itinerary"
-description: "A practical AI trip planning checklist for travellers who want more than a generic list of attractions. Learn how to set constraints, validate transfers, pressure-test pacing, and move toward a bookable trip."
-keywords: "how to plan a trip with AI, AI trip planning checklist, AI travel planner, multi-city trip planning, itinerary validation, Alfred Travel"
+description: "A practical AI trip planning checklist and copy-and-paste trip brief for travellers who want more than a generic list of attractions. Learn how to set constraints, validate transfers, pressure-test pacing, and move toward a bookable trip."
+keywords: "how to plan a trip with AI, AI trip planning checklist, AI travel planner, trip brief template, multi-city trip planning, itinerary validation, Alfred Travel"
 date: "2026-06-15"
-excerpt: "If you use AI for travel planning, the hardest part is not getting ideas. It is turning those ideas into a route that still works once transfers, pacing, hotel location, and booking decisions enter the picture."
+excerpt: "If you use AI for travel planning, the hardest part is not getting ideas. It is turning those ideas into a route that still works once transfers, pacing, hotel location, and booking decisions enter the picture—and giving the model a brief specific enough to return usable options."
 author: "Alfred Team"
 category: "AI Travel"
 tags: ["AI Trip Planning", "Travel Checklist", "Itinerary Validation"]
 takeaways:
   - "Good AI trip planning starts with constraints such as travel days, transfer tolerance, budget shape, and who is travelling—not with a generic list of attractions."
   - "A useful AI travel plan needs validation for route order, hotel location, transfer buffers, and recovery time before you book anything."
-  - "Clear, structured answers beat vague inspiration when travellers compare planners in Google, ChatGPT, and other answer engines."
+  - "A reusable trip brief template helps travellers get structured answers they can compare, edit, and reuse across Google, ChatGPT, and planner tools."
 faqs:
   - question: "How should I use AI to plan a trip?"
     answer: "Use AI to build and compare route options, then validate timing, hotel fit, and pacing before booking. The best results come from giving the model real constraints instead of broad prompts."
@@ -18,6 +18,8 @@ faqs:
     answer: "They often start from attraction lists instead of traveller constraints. That leads to schedules that look polished but ignore transfer friction, energy levels, and booking realities."
   - question: "What should an AI travel planner validate before booking?"
     answer: "At minimum: route order, airport or rail transfer windows, hotel location relative to your day plan, day density, and whether a long-haul or red-eye requires recovery time."
+  - question: "What details should I give AI before asking for an itinerary?"
+    answer: "Include dates, arrival and departure cities, number of stops, transfer tolerance, budget shape, accommodation preferences, and any pace constraints such as travelling with children or needing recovery time after long-haul flights."
   - question: "Can AI plan a multi-city trip well?"
     answer: "Yes, but only when the planner checks sequencing and buffers. Multi-city trips break when each leg is treated as an isolated suggestion rather than part of one connected route."
 ---
@@ -99,7 +101,23 @@ Before you book, ask whether the plan can pass this checklist:
 7. **Each leg still works if something slips.**  
    Good trips survive delay; brittle trips collapse.
 
-## 5) Keep the answers structured enough to reuse
+## 5) Copy and paste a trip brief before you ask for options
+
+A vague prompt invites a vague answer. Before you ask for route ideas, write a short brief the model can actually use:
+
+> Plan a trip for **[who is travelling]** from **[start date]** to **[end date]**.  
+> Start in **[arrival city]** and end in **[departure city]**.  
+> I want **[number of cities / regions]** with **[low / medium / high]** pacing.  
+> Prioritise **[must-do experiences]** and avoid **[deal-breakers]**.  
+> Keep transfer days under **[time limit]** when possible.  
+> Budget shape: **[save on hotels / spend on location / balanced]**.  
+> Accommodation preference: **[hotel / apartment / mixed]**.  
+> Important constraints: **[children, accessibility needs, late arrival, early flight, remote work hours, loyalty status, etc.]**.  
+> Return 3 route options, key trade-offs, and any travel-day risks before giving a day-by-day itinerary.
+
+This is much closer to how a real traveller plans than asking for “the best itinerary.” It also makes the outputs easier to compare across Google, ChatGPT, and dedicated trip-planning tools.
+
+## 6) Keep the answers structured enough to reuse
 
 Google’s AI-search guidance increasingly rewards **clear, useful, non-commodity content**. The same principle applies when you use AI to plan a trip for yourself: structure beats noise.
 
@@ -115,7 +133,7 @@ That is far more reusable than a wall of generic prose.
 
 If you are comparing options, save the output in sections such as **route**, **timing risks**, **hotel logic**, and **trade-offs**. This makes it easier to judge whether the planner is helping you think or just generating volume.
 
-## 6) Use AI differently for single-city and multi-city trips
+## 7) Use AI differently for single-city and multi-city trips
 
 A single-city trip mostly needs help with **neighbourhood fit, day clustering, and pacing**.
 
@@ -123,9 +141,9 @@ A multi-city trip needs help with **sequence, transport legs, recovery windows, 
 
 That distinction matters because a planner that looks strong on destination ideas can still fail when you cross a border or add multiple hotel changes. If your trip has more moving parts, you need a planner that behaves more like a logistics layer than a chat surface.
 
-For a route with multiple stops, start with Alfred’s [AI Trip Planner](../ai-trip-planner/index.html), then compare the output against destination examples in the [itinerary library](../itineraries/index.html).
+For a route with multiple stops, start with Alfred’s [AI Trip Planner](../ai-trip-planner/index.html), then compare the output against destination examples in the [itinerary library](../itineraries/index.html). If you are planning for children or a group, pressure-test the result against our guides to [family pacing](../blog/bali-for-families.html) and [group preference trade-offs](../blog/future-of-group-planning.html). If the stay type is still unclear, use the [hotel vs Airbnb logic guide](../blog/ai-hotel-vs-airbnb-logic.html) before you book.
 
-## 7) Do not let AI hide trade-offs from you
+## 8) Do not let AI hide trade-offs from you
 
 A generic itinerary usually pretends you can have everything at once:
 

--- a/content/blog/how-to-plan-a-trip-with-ai-without-generic-itineraries.md
+++ b/content/blog/how-to-plan-a-trip-with-ai-without-generic-itineraries.md
@@ -22,6 +22,8 @@ faqs:
     answer: "Include dates, arrival and departure cities, number of stops, transfer tolerance, budget shape, accommodation preferences, and any pace constraints such as travelling with children or needing recovery time after long-haul flights."
   - question: "What details should I add when points, borders, or family logistics matter?"
     answer: "Tell the planner about loyalty programs, points-versus-cash preferences, passport or visa constraints, baggage tolerance, latest acceptable arrival times, and family timing limits. Those details change route order, hotel choice, and whether a transfer is actually safe."
+  - question: "What follow-up prompt should I ask after the first AI itinerary?"
+    answer: "Ask the model to rank the options by transfer risk, hotel switching, and recovery time, then rewrite the best option with warnings for borders, points, or family timing. The second pass is usually where a generic itinerary becomes usable."
   - question: "Can AI plan a multi-city trip well?"
     answer: "Yes, but only when the planner checks sequencing and buffers. Multi-city trips break when each leg is treated as an isolated suggestion rather than part of one connected route."
 ---
@@ -134,7 +136,22 @@ Before you accept a route, add the constraints that most often change the answer
 
 If your trip mixes rail and flights, pressure-test the answer with our [rail vs flight cost analysis](../blog/rail-vs-flight-cost-analysis.html). If you are balancing adults, kids, or different travel styles, cross-check the route against [family pacing](../blog/bali-for-families.html) and [group preference trade-offs](../blog/future-of-group-planning.html) before booking.
 
-## 7) Keep the answers structured enough to reuse
+## 7) Use follow-up prompts to force trade-offs into the open
+
+A first AI itinerary can sound confident while still hiding the real compromises. The fastest way to improve it is to ask a **second-pass prompt** that forces the model to explain what breaks first.
+
+Use follow-up prompts like these:
+
+| If your trip depends on... | Ask AI this follow-up prompt | A useful answer should include |
+| --- | --- | --- |
+| Comparing route shapes | "Rank these options by least transfer risk, least hotel switching, and best recovery time after arrival. Tell me which city should be cut first if I need a simpler trip." | A ranked recommendation, the main trade-off in each option, and the first stress point to remove |
+| Points or loyalty rules | "Rewrite this route assuming I prefer alliance-friendly flights, want to compare points versus cash, and do not want a repositioning leg unless it saves a major amount." | Cash-versus-points pinch points, reposition warnings, and where loyalty preferences change the route |
+| Borders or major events | "Stress-test this itinerary for border queues, event-day crowding, and the latest safe arrival time for each transfer day." | Brittle same-day legs, buffer recommendations, and any stop that needs an earlier arrival |
+| Family or mixed-energy pacing | "Rewrite this plan with one recovery block after heavy travel days, shorter walking windows, and one low-friction backup option per day." | A lighter day structure, neighbourhood logic, and where over-scheduling is most likely |
+
+If the answer still refuses to show trade-offs, the planner is probably generating polished text instead of helping you make decisions. That is a good time to compare the route against Alfred’s [hotel vs Airbnb logic guide](../blog/ai-hotel-vs-airbnb-logic.html) or the [AI Trip Planner](../ai-trip-planner/index.html) before you book.
+
+## 8) Keep the answers structured enough to reuse
 
 Google’s AI-search guidance increasingly rewards **clear, useful, non-commodity content**. The same principle applies when you use AI to plan a trip for yourself: structure beats noise.
 
@@ -150,7 +167,7 @@ That is far more reusable than a wall of generic prose.
 
 If you are comparing options, save the output in sections such as **route**, **timing risks**, **hotel logic**, and **trade-offs**. This makes it easier to judge whether the planner is helping you think or just generating volume.
 
-## 8) Use AI differently for single-city and multi-city trips
+## 9) Use AI differently for single-city and multi-city trips
 
 A single-city trip mostly needs help with **neighbourhood fit, day clustering, and pacing**.
 
@@ -160,7 +177,7 @@ That distinction matters because a planner that looks strong on destination idea
 
 For a route with multiple stops, start with Alfred’s [AI Trip Planner](../ai-trip-planner/index.html), then compare the output against destination examples in the [itinerary library](../itineraries/index.html). If you are planning for children or a group, pressure-test the result against our guides to [family pacing](../blog/bali-for-families.html) and [group preference trade-offs](../blog/future-of-group-planning.html). If the stay type is still unclear, use the [hotel vs Airbnb logic guide](../blog/ai-hotel-vs-airbnb-logic.html) before you book.
 
-## 9) Do not let AI hide trade-offs from you
+## 10) Do not let AI hide trade-offs from you
 
 A generic itinerary usually pretends you can have everything at once:
 

--- a/index.html
+++ b/index.html
@@ -135,7 +135,7 @@
                         <div class="tai-hero-actions">
                             <a href="#app-downloads" class="tai-btn-primary">Download now</a>
                         </div>
-                        <p class="tai-hero-lead">If you are still comparing planners, start with our <a href="blog/how-to-plan-a-trip-with-ai-without-generic-itineraries.html">AI trip planning checklist</a> and then see <a href="compare/index.html">how Alfred handles route validation</a>.</p>
+                        <p class="tai-hero-lead">If you are still comparing planners, start with our <a href="blog/how-to-plan-a-trip-with-ai-without-generic-itineraries.html">AI trip planning checklist</a>, use the <a href="blog/family-itinerary-with-nap-window-logic.html">family itinerary pacing guide</a> when timing gets fragile, review the <a href="blog/ai-hotel-vs-airbnb-logic.html">hotel-vs-Airbnb decision guide</a>, and then see <a href="compare/index.html">how Alfred handles route validation</a>.</p>
                     </div>
                 </div>
             </div>

--- a/index.html
+++ b/index.html
@@ -135,6 +135,7 @@
                         <div class="tai-hero-actions">
                             <a href="#app-downloads" class="tai-btn-primary">Download now</a>
                         </div>
+                        <p class="tai-hero-lead">If you are still comparing planners, start with our <a href="blog/how-to-plan-a-trip-with-ai-without-generic-itineraries.html">AI trip planning checklist</a> and then see <a href="compare/index.html">how Alfred handles route validation</a>.</p>
                     </div>
                 </div>
             </div>

--- a/products.html
+++ b/products.html
@@ -96,6 +96,7 @@
                         <div class="tai-hero-actions">
                             <a href="index.html#app-downloads" class="tai-btn-primary">Download App</a>
                         </div>
+                        <p class="tai-hero-lead">Need a practical starting point first? Read the <a href="blog/how-to-plan-a-trip-with-ai-without-generic-itineraries.html">AI trip planning checklist</a> for route comparison, transfer buffers, points rules, and family pacing questions.</p>
                     </div>
                 </div>
             </div>

--- a/products.html
+++ b/products.html
@@ -96,7 +96,7 @@
                         <div class="tai-hero-actions">
                             <a href="index.html#app-downloads" class="tai-btn-primary">Download App</a>
                         </div>
-                        <p class="tai-hero-lead">Need a practical starting point first? Read the <a href="blog/how-to-plan-a-trip-with-ai-without-generic-itineraries.html">AI trip planning checklist</a> for route comparison, transfer buffers, points rules, and family pacing questions.</p>
+                        <p class="tai-hero-lead">Need a practical starting point first? Read the <a href="blog/how-to-plan-a-trip-with-ai-without-generic-itineraries.html">AI trip planning checklist</a> for route comparison, then use the <a href="blog/family-itinerary-with-nap-window-logic.html">family itinerary pacing guide</a> or <a href="blog/ai-hotel-vs-airbnb-logic.html">hotel-vs-Airbnb decision guide</a> when trip structure—not destination inspiration—is the blocker.</p>
                     </div>
                 </div>
             </div>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -12,6 +12,7 @@
   <url><loc>https://www.alfredtravel.io/terms.html</loc><changefreq>monthly</changefreq><priority>0.5</priority></url>
   <url><loc>https://www.alfredtravel.io/delete-account.html</loc><changefreq>monthly</changefreq><priority>0.5</priority></url>
   <url><loc>https://www.alfredtravel.io/prize-tc.html</loc><changefreq>monthly</changefreq><priority>0.5</priority></url>
+  <url><loc>https://www.alfredtravel.io/blog/how-to-plan-a-trip-with-ai-without-generic-itineraries.html</loc><lastmod>2026-06-15</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
   <url><loc>https://www.alfredtravel.io/blog/india-travel-ai-delhi-execution.html</loc><lastmod>2026-06-11</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
   <url><loc>https://www.alfredtravel.io/blog/skift-b2a-ai-agents-travel-alfred-aio.html</loc><lastmod>2026-05-25</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
   <url><loc>https://www.alfredtravel.io/blog/skift-india-voice-first-travel-alfred.html</loc><lastmod>2026-05-24</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -12,6 +12,7 @@
   <url><loc>https://www.alfredtravel.io/terms.html</loc><changefreq>monthly</changefreq><priority>0.5</priority></url>
   <url><loc>https://www.alfredtravel.io/delete-account.html</loc><changefreq>monthly</changefreq><priority>0.5</priority></url>
   <url><loc>https://www.alfredtravel.io/prize-tc.html</loc><changefreq>monthly</changefreq><priority>0.5</priority></url>
+  <url><loc>https://www.alfredtravel.io/blog/ai-hotel-vs-airbnb-logic.html</loc><lastmod>2026-06-20</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
   <url><loc>https://www.alfredtravel.io/blog/how-to-plan-a-trip-with-ai-without-generic-itineraries.html</loc><lastmod>2026-06-15</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
   <url><loc>https://www.alfredtravel.io/blog/india-travel-ai-delhi-execution.html</loc><lastmod>2026-06-11</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
   <url><loc>https://www.alfredtravel.io/blog/skift-b2a-ai-agents-travel-alfred-aio.html</loc><lastmod>2026-05-25</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
@@ -44,7 +45,6 @@
   <url><loc>https://www.alfredtravel.io/blog/death-of-generic-itineraries-personalized.html</loc><lastmod>2026-01-05</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
   <url><loc>https://www.alfredtravel.io/blog/rail-vs-flight-cost-analysis.html</loc><lastmod>2025-12-25</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
   <url><loc>https://www.alfredtravel.io/blog/death-of-human-agents.html</loc><lastmod>2025-12-17</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
-  <url><loc>https://www.alfredtravel.io/blog/ai-hotel-vs-airbnb-logic.html</loc><lastmod>2025-12-16</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
   <url><loc>https://www.alfredtravel.io/blog/road-trip-mastery-turn-by-turn-ai.html</loc><lastmod>2025-12-01</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
   <url><loc>https://www.alfredtravel.io/blog/madrid-vs-barcelona.html</loc><lastmod>2025-11-26</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
   <url><loc>https://www.alfredtravel.io/blog/iceland-ring-road.html</loc><lastmod>2025-11-18</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>


### PR DESCRIPTION
## Summary
This PR was created by the agent, is branched from `gh-pages`, and targets `gh-pages`.

This run **updated the existing open ga-growth PR instead of opening a duplicate** because the analytics opportunity is still the same: Alfred’s highest-traffic landing pages need stronger paths into practical planning content, and the content behind those paths needs to be more useful once visitors click.

## Analytics observations
Source: Google Analytics Reports snapshot and Pages and screens report, extracted from the live authenticated Google Analytics tab via CDP.
Visible date range on the reused Analytics tab: **Last 90 days (22 Mar - 19 Jun 2026)**.

Top-line metrics visible:
- Active users: **896**
- New users: **974**
- Average engagement time per active user: **25s**
- Event count: **8.3k**

Top pages/screens visible on the report snapshot:
- `Alfred Travel: AI-powered travel planning you can actually book` — **1.2k views**, **574 active users**, **4.7k events**, **52.4% bounce rate**
- `AI Trip Planner, AI Travel Planner & AI Holiday Planner | Alfred` — **442 views**, **282 active users**, **1.8k events**, **50.0% bounce rate**
- `Alfred | #1 AI Trip Planner for Multi-City Logistical Validation` — **130 views**, **370 events**, **33.3% bounce rate**
- `Alfred features | AI trip planning, validation and booking tools` — **103 views**, **46 active users**, **337 events**, **11.9% bounce rate**
- `About Alfred Travel | AI-powered trip planning platform` — **63 views**, **30 active users**, **216 events**, **19.4% bounce rate**

Top page paths visible on the Pages and screens report:
- `/` — **1,522 views**, **821 active users**, **20s average engagement time**, **6,052 events**
- `/index.html` — **262 views**, **97 active users**, **21s average engagement time**, **904 events**
- `/products.html` — **150 views**, **79 active users**, **20s average engagement time**, **493 events**
- `/about.html` — **63 views**, **30 active users**, **29s average engagement time**, **216 events**
- `/blog/index.html` — **7 views**, **4 active users**, **5s average engagement time**, **24 events**

Acquisition signals visible:
- First user source / medium: `(direct) / (none)` **478**, `google / organic` **174**, `ig / social` **108**, `linkedin.com / referral` **62**, `chatgpt.com / (not set)` **13**, `chatgpt.com / referral` **12`
- Session source / medium: `(direct) / (none)` **632**, `google / organic` **285**, `ig / social` **114**, `linkedin.com / referral` **69**, `chatgpt.com / (not set)` **18**, `chatgpt.com / referral` **13`

Opportunity signal:
- Alfred’s broad landing pages and AI Trip Planner page are still doing most of the traffic capture.
- Those same entry pages show weaker bounce/engagement performance than deeper utility pages.
- Blog visibility is still low in the visible path report, which means Alfred needs not only more pathways into useful blog content, but also stronger content quality once those visitors arrive.
- The **hotel-vs-Airbnb** decision is a practical, decision-stage question that fits Alfred’s traffic profile and complements the internal-link path already in this PR line.

## Opportunity chosen
Deepen one of the practical blog guides already being surfaced from Alfred’s high-traffic landing pages: the hotel-vs-Airbnb decision guide.

This run adds:
- a substantially expanded, more useful **hotel-vs-Airbnb** guide with decision logic for short breaks, multi-city trips, late arrivals, family travel, remote work, and trip-risk trade-offs
- FAQ-style answers in frontmatter so the generated page includes **FAQPage structured data**
- a stronger AI Trip Planner internal link path into the stay-choice guide and family-pacing guide

## Relevant Google AI-optimization guidance used
Reviewed via the Google Search Central guide:
https://developers.google.com/search/docs/fundamentals/ai-optimization-guide

Applied guidance from Google:
- create **valuable, non-commodity content** that adds original decision utility instead of generic accommodation tips
- organize content with **clear sections, headings, tables, and FAQ-style answers** so it is easier for readers and retrieval systems to parse
- use **helpful internal links** from broad entry pages into more specific answer content
- focus on **people-first usefulness** rather than unsupported GEO/AEO tactics such as chunking, llms.txt files, or AI-only rewrites
- preserve **clear technical structure** and crawlable HTML while keeping the existing layout stable

## External sources reviewed this run
Reviewed through the live Chromium/CDP session.

1. **PhocusWire** (`https://www.phocuswire.com/`)
   - Visible signals reviewed: `AI is the next productivity shock: Can travel reap the gains?`, `Hotels face speed problem as video platforms reshape the booking journey`, and `Cendyn launches Wayfinder to help hotels avoid "OTA 2.0"`.
   - Influence on this change: reinforced that Alfred should answer concrete decision-stage booking questions quickly and clearly, not just describe product capabilities.

2. **Nomadic Matt** (`https://www.nomadicmatt.com/`)
   - Visible signals reviewed: `How to Plan Your Trip`, `Finding Accommodation`, `16 Steps for Planning a Trip`, and `Family & Senior Travel`.
   - Influence on this change: supported building a more structured, step-based accommodation guide rather than leaving the topic as a short opinion piece.

3. **The Points Guy** (`https://thepointsguy.com/`)
   - Visible signals reviewed: utility-led entry points such as `TSA wait times`, `Awards calculator`, `Points valuations`, and travel-planning guides.
   - Influence on this change: validated the importance of decision tools that help travelers compare trade-offs, not just consume inspiration.

4. **WTTC** (`https://wttc.org/news`)
   - Visible signals reviewed: `FIFA World Cup 2026 Sets New Benchmark for Trusted, Seamless Travel Across Borders` and `Up to 41 Million European Visitor Arrivals at Risk if EES Border Delays Reach Three Hours`.
   - Influence on this change: reinforced the value of accommodation guidance that accounts for border friction, transport timing, and operational reliability.

## Why this may improve traffic / viewership / engagement / AI-search visibility
- Strengthens one of the practical blog assets already linked from Alfred’s landing pages, which should improve usefulness once visitors click through.
- Better matches the intent of visitors who arrive from Google, direct, and ChatGPT-style sources with a real decision framework instead of generic lodging advice.
- Adds structured, snippet-friendly content with clear headings, tables, checklists, and FAQs that are easier for Google Search AI features and chat-style retrieval systems to ground in.
- Improves the AI Trip Planner page’s onward path into deeper content without changing the layout.
- Keeps the PR focused on Alfred’s strongest current opportunity cluster: converting broad trip-planning interest into deeper practical planning engagement.

## Files changed
Updated in this run:
- `content/blog/ai-hotel-vs-airbnb-logic.md`
- `blog/ai-hotel-vs-airbnb-logic.html`
- `blog/index.html`
- `ai-trip-planner/index.html`
- `sitemap.xml`

## Validation commands and outcomes
- `npm run build:blog` ✅
- `npm run build:itineraries` ✅
- `npm run build:compare` ✅
- `npm test` not run because `package.json` currently has **no test script**

Additional spot checks via CDP on local built files:
- `ai-trip-planner/index.html` reload confirmed the updated internal-link paragraph is present and `scrollWidth == clientWidth` (no horizontal overflow)
- `blog/ai-hotel-vs-airbnb-logic.html` confirmed the expanded decision table, validation checklist, and FAQ schema are present

## Constraints respected
- Existing site layout was intentionally preserved.
- No redesign or layout refactor was introduced.
- The change remains content-led and focused on making blog content more useful and better connected to high-traffic landing pages.
- This PR was created by the agent and updated by the agent on this run.
- The branch is based on `gh-pages`, and the PR targets `gh-pages`.
